### PR TITLE
Add RRULE recurrence interval parser

### DIFF
--- a/src/__tests__/recurrenceUtils.test.ts
+++ b/src/__tests__/recurrenceUtils.test.ts
@@ -1,0 +1,135 @@
+import { parseRecurrenceIntervalDays } from '../utils/recurrenceUtils';
+
+describe('parseRecurrenceIntervalDays', () => {
+	describe('RRULE format', () => {
+		it('FREQ=DAILY returns 1', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=DAILY')).toBe(1);
+		});
+
+		it('FREQ=DAILY;INTERVAL=2 returns 2', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=DAILY;INTERVAL=2')).toBe(2);
+		});
+
+		it('FREQ=DAILY;INTERVAL=5 returns 5', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=DAILY;INTERVAL=5')).toBe(5);
+		});
+
+		it('FREQ=WEEKLY returns 7', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=WEEKLY')).toBe(7);
+		});
+
+		it('FREQ=WEEKLY;INTERVAL=2 returns 14', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=WEEKLY;INTERVAL=2')).toBe(14);
+		});
+
+		it('FREQ=MONTHLY returns 30', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=MONTHLY')).toBe(30);
+		});
+
+		it('FREQ=MONTHLY;INTERVAL=3 returns 90', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=MONTHLY;INTERVAL=3')).toBe(90);
+		});
+
+		it('is case-insensitive', () => {
+			expect(parseRecurrenceIntervalDays('freq=daily')).toBe(1);
+			expect(parseRecurrenceIntervalDays('Freq=Weekly')).toBe(7);
+			expect(parseRecurrenceIntervalDays('freq=monthly;interval=2')).toBe(60);
+		});
+	});
+
+	describe('BYDAY average-interval heuristic', () => {
+		it('BYDAY=MO,WE,FR (3 days) returns 2', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=WEEKLY;BYDAY=MO,WE,FR')).toBe(2);
+		});
+
+		it('BYDAY=MO,FR (2 days) returns 4', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=WEEKLY;BYDAY=MO,FR')).toBe(4);
+		});
+
+		it('BYDAY=TU (1 day) returns 7', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=WEEKLY;BYDAY=TU')).toBe(7);
+		});
+
+		it('BYDAY=MO,TU,WE,TH,FR (5 days) returns 1', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR')).toBe(1);
+		});
+
+		it('BYDAY=MO,TU,WE,TH,FR,SA,SU (7 days) returns 1', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU')).toBe(1);
+		});
+	});
+
+	describe('DTSTART prefix stripping', () => {
+		it('strips DTSTART before parsing FREQ', () => {
+			expect(parseRecurrenceIntervalDays('DTSTART:20250118;FREQ=WEEKLY;BYDAY=FR')).toBe(7);
+		});
+
+		it('strips DTSTART with FREQ=DAILY', () => {
+			expect(parseRecurrenceIntervalDays('DTSTART:20250101;FREQ=DAILY')).toBe(1);
+		});
+
+		it('strips DTSTART case-insensitively', () => {
+			expect(parseRecurrenceIntervalDays('dtstart:20250118;FREQ=MONTHLY')).toBe(30);
+		});
+	});
+
+	describe('legacy human-readable patterns (backward compat)', () => {
+		it('"every day" returns 1', () => {
+			expect(parseRecurrenceIntervalDays('every day')).toBe(1);
+		});
+
+		it('"daily" returns 1', () => {
+			expect(parseRecurrenceIntervalDays('daily')).toBe(1);
+		});
+
+		it('"every 2 days" returns 2', () => {
+			expect(parseRecurrenceIntervalDays('every 2 days')).toBe(2);
+		});
+
+		it('"every 10 days" returns 10', () => {
+			expect(parseRecurrenceIntervalDays('every 10 days')).toBe(10);
+		});
+
+		it('"every week" returns 7', () => {
+			expect(parseRecurrenceIntervalDays('every week')).toBe(7);
+		});
+
+		it('"weekly" returns 7', () => {
+			expect(parseRecurrenceIntervalDays('weekly')).toBe(7);
+		});
+
+		it('"every 2 weeks" returns 14', () => {
+			expect(parseRecurrenceIntervalDays('every 2 weeks')).toBe(14);
+		});
+
+		it('"every month" returns 30', () => {
+			expect(parseRecurrenceIntervalDays('every month')).toBe(30);
+		});
+
+		it('"monthly" returns 30', () => {
+			expect(parseRecurrenceIntervalDays('monthly')).toBe(30);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('unrecognized string returns 1', () => {
+			expect(parseRecurrenceIntervalDays('something unknown')).toBe(1);
+		});
+
+		it('empty string returns 1', () => {
+			expect(parseRecurrenceIntervalDays('')).toBe(1);
+		});
+
+		it('whitespace-only returns 1', () => {
+			expect(parseRecurrenceIntervalDays('   ')).toBe(1);
+		});
+
+		it('trims whitespace around valid RRULE', () => {
+			expect(parseRecurrenceIntervalDays('  FREQ=WEEKLY  ')).toBe(7);
+		});
+
+		it('unrecognized FREQ returns 1', () => {
+			expect(parseRecurrenceIntervalDays('FREQ=YEARLY')).toBe(1);
+		});
+	});
+});

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -1,4 +1,5 @@
 import { formatISODate, getTodayUTC, isSameDay, addDays } from './utils/dateUtils';
+import { parseRecurrenceIntervalDays } from './utils/recurrenceUtils';
 
 export interface DayCell {
 	date: Date;
@@ -36,7 +37,7 @@ export class GraphRenderer {
 		lastCompletion.setHours(0, 0, 0, 0);
 
 		// Parse recurrence to get ideal interval (in days)
-		const intervalDays = this.parseRecurrenceInterval(recurrencePattern);
+		const intervalDays = parseRecurrenceIntervalDays(recurrencePattern);
 
 		// Generate cells from past to future
 		for (let i = -daysBefore; i <= daysAfter; i++) {
@@ -85,50 +86,6 @@ export class GraphRenderer {
 		}
 
 		return cells;
-	}
-
-	/**
-	 * Parse recurrence pattern to get interval in days
-	 *
-	 * Supported patterns:
-	 * - "daily" or "every day" → 1 day
-	 * - "every N days" (e.g., "every 2 days", "every 10 days") → N days
-	 * - "weekly" or "every week" → 7 days
-	 * - "every N weeks" (e.g., "every 2 weeks", "every 4 weeks") → N * 7 days
-	 * - "monthly" or "every month" → 30 days
-	 *
-	 * Unrecognized patterns will log a console warning and default to daily (1 day).
-	 *
-	 * @param pattern - The recurrence pattern string (case-insensitive)
-	 * @returns The interval in days
-	 */
-	private static parseRecurrenceInterval(pattern: string): number {
-		pattern = pattern.toLowerCase();
-
-		// Check exact/simple patterns first
-		if (pattern.includes('every day') || pattern.includes('daily')) {
-			return 1;
-		} else if (pattern.includes('every week') || pattern.includes('weekly')) {
-			return 7;
-		} else if (pattern.includes('every month') || pattern.includes('monthly')) {
-			return 30;
-		}
-
-		// Try generalized "every N days" pattern
-		const daysMatch = pattern.match(/every (\d+) days?/i);
-		if (daysMatch) {
-			return parseInt(daysMatch[1]);
-		}
-
-		// Try generalized "every N weeks" pattern
-		const weeksMatch = pattern.match(/every (\d+) weeks?/i);
-		if (weeksMatch) {
-			return parseInt(weeksMatch[1]) * 7;
-		}
-
-		// Unrecognized pattern - log warning and default to daily
-		console.warn(`Unrecognized recurrence pattern: "${pattern}". Defaulting to daily (1 day). Supported patterns: daily, every N days, weekly, every N weeks, monthly.`);
-		return 1;
 	}
 
 	/**

--- a/src/utils/recurrenceUtils.ts
+++ b/src/utils/recurrenceUtils.ts
@@ -1,0 +1,58 @@
+/**
+ * Parse recurrence pattern to get interval in days.
+ *
+ * Supports RRULE format (FREQ=DAILY, FREQ=WEEKLY, etc.) and
+ * legacy human-readable patterns ("every day", "weekly", etc.).
+ * BYDAY uses average interval: FREQ=WEEKLY;BYDAY=MO,WE,FR → 7/3 ≈ 2 days.
+ * Proper day-of-week scheduling is tracked in #11.
+ */
+export function parseRecurrenceIntervalDays(pattern: string): number {
+	const trimmed = pattern.trim();
+
+	// Strip DTSTART prefix if present (e.g. "DTSTART:20250118;FREQ=WEEKLY;BYDAY=FR")
+	const rruleStr = trimmed.replace(/^DTSTART:[^;]*;?/i, '');
+
+	if (rruleStr.toUpperCase().includes('FREQ=')) {
+		const params: Record<string, string> = {};
+		for (const part of rruleStr.split(';')) {
+			const eq = part.indexOf('=');
+			if (eq > 0) {
+				params[part.substring(0, eq).toUpperCase()] = part.substring(eq + 1).toUpperCase();
+			}
+		}
+
+		const freq = params['FREQ'] ?? '';
+		const interval = parseInt(params['INTERVAL'] ?? '1', 10) || 1;
+
+		if (freq === 'DAILY') return interval;
+
+		if (freq === 'WEEKLY') {
+			if (params['BYDAY']) {
+				const count = params['BYDAY'].split(',').filter(Boolean).length;
+				return Math.max(1, Math.round(7 / count));
+			}
+			return 7 * interval;
+		}
+
+		if (freq === 'MONTHLY') return 30 * interval;
+
+		console.warn(`Unrecognized RRULE FREQ: "${freq}". Defaulting to daily (1 day).`);
+		return 1;
+	}
+
+	// Legacy human-readable fallback (kept per PROJECT_LORE.md constraint)
+	const lower = trimmed.toLowerCase();
+
+	if (lower.includes('every day') || lower.includes('daily')) return 1;
+	if (lower.includes('every week') || lower.includes('weekly')) return 7;
+	if (lower.includes('every month') || lower.includes('monthly')) return 30;
+
+	const daysMatch = lower.match(/every (\d+) days?/);
+	if (daysMatch) return parseInt(daysMatch[1], 10);
+
+	const weeksMatch = lower.match(/every (\d+) weeks?/);
+	if (weeksMatch) return parseInt(weeksMatch[1], 10) * 7;
+
+	console.warn(`Unrecognized recurrence pattern: "${trimmed}". Defaulting to daily (1 day).`);
+	return 1;
+}


### PR DESCRIPTION
## Summary

- Extract `parseRecurrenceInterval` from `GraphRenderer` (private static) to `parseRecurrenceIntervalDays` in `src/utils/recurrenceUtils.ts` (exported, testable)
- Add RRULE format parsing: `FREQ=DAILY`, `FREQ=WEEKLY`, `FREQ=MONTHLY` with `INTERVAL` and `BYDAY` support
- BYDAY uses average-interval heuristic (`Math.round(7 / dayCount)`) — proper day-of-week scheduling tracked in #11
- Legacy human-readable patterns ("every day", "weekly", etc.) retained as fallback per PROJECT_LORE.md constraint
- **Decision: hand-rolled parser, no `rrule` npm dependency** — we only need a single integer, not occurrence generation; rrule would add 46 KB to a 17 KB bundle

Closes #17

## Test plan

- [x] 30 new unit tests in `recurrenceUtils.test.ts` covering:
  - All FREQ variants (DAILY, WEEKLY, MONTHLY) with INTERVAL modifier
  - BYDAY heuristic (1, 2, 3, 5, 7 days)
  - DTSTART prefix stripping
  - Case insensitivity
  - Legacy human-readable backward compat (9 tests)
  - Edge cases (empty, whitespace, unrecognized, FREQ=YEARLY)
- [x] All 47 tests pass (`npm test`)
- [x] `npm run build` — clean TypeScript + production bundle
- [x] No breaking changes to existing `GraphRenderer.generateDayCells` callers