### PR TITLE
Migrate API + cache layer to TaskNote data model

### DIFF
--- a/src/__tests__/taskCacheManager.test.ts
+++ b/src/__tests__/taskCacheManager.test.ts
@@ -1,0 +1,167 @@
+import { TaskCacheManager } from '../cache/TaskCacheManager';
+import { TaskNote } from '../types';
+
+function makeTaskNote(overrides: Partial<TaskNote> = {}): TaskNote {
+	return {
+		title: 'Test task',
+		status: 'open',
+		recurrence: 'FREQ=DAILY',
+		recurrenceAnchor: 'scheduled',
+		tags: ['habit'],
+		path: 'tasks/test.md',
+		completeInstances: [],
+		skippedInstances: [],
+		...overrides
+	};
+}
+
+describe('TaskCacheManager', () => {
+	let cache: TaskCacheManager;
+
+	beforeEach(() => {
+		cache = new TaskCacheManager();
+	});
+
+	it('starts empty', () => {
+		expect(cache.isEmpty()).toBe(true);
+		expect(cache.getAllCachedTasks()).toEqual([]);
+	});
+
+	describe('setFileTasks / getFileTasks', () => {
+		it('stores and retrieves a TaskNote', () => {
+			const task = makeTaskNote({ title: 'Workout' });
+			cache.setFileTasks('tasks/workout.md', task);
+
+			expect(cache.getFileTasks('tasks/workout.md')).toEqual(task);
+			expect(cache.isEmpty()).toBe(false);
+		});
+
+		it('returns null for unknown file', () => {
+			expect(cache.getFileTasks('nonexistent.md')).toBeNull();
+		});
+
+		it('overwrites existing entry', () => {
+			cache.setFileTasks('a.md', makeTaskNote({ title: 'V1' }));
+			cache.setFileTasks('a.md', makeTaskNote({ title: 'V2' }));
+
+			expect(cache.getFileTasks('a.md')!.title).toBe('V2');
+		});
+
+		it('clears dirty flag on set', () => {
+			cache.setFileTasks('a.md', makeTaskNote());
+			cache.invalidateFile('a.md');
+			expect(cache.isFileDirty('a.md')).toBe(true);
+
+			cache.setFileTasks('a.md', makeTaskNote());
+			expect(cache.isFileDirty('a.md')).toBe(false);
+		});
+	});
+
+	describe('bulkSet', () => {
+		it('populates cache from map', () => {
+			const map = new Map<string, TaskNote>();
+			map.set('a.md', makeTaskNote({ title: 'A' }));
+			map.set('b.md', makeTaskNote({ title: 'B' }));
+			cache.bulkSet(map);
+
+			expect(cache.getAllCachedTasks()).toHaveLength(2);
+			expect(cache.getFileTasks('a.md')!.title).toBe('A');
+			expect(cache.getFileTasks('b.md')!.title).toBe('B');
+		});
+
+		it('clears previous entries', () => {
+			cache.setFileTasks('old.md', makeTaskNote({ title: 'Old' }));
+			cache.bulkSet(new Map([['new.md', makeTaskNote({ title: 'New' })]]));
+
+			expect(cache.getFileTasks('old.md')).toBeNull();
+			expect(cache.getFileTasks('new.md')!.title).toBe('New');
+		});
+	});
+
+	describe('removeFile', () => {
+		it('removes entry from cache', () => {
+			cache.setFileTasks('a.md', makeTaskNote());
+			cache.removeFile('a.md');
+
+			expect(cache.getFileTasks('a.md')).toBeNull();
+			expect(cache.isEmpty()).toBe(true);
+		});
+
+		it('clears dirty flag', () => {
+			cache.setFileTasks('a.md', makeTaskNote());
+			cache.invalidateFile('a.md');
+			cache.removeFile('a.md');
+
+			expect(cache.isFileDirty('a.md')).toBe(false);
+		});
+	});
+
+	describe('renameFile', () => {
+		it('moves entry to new path and updates path field', () => {
+			cache.setFileTasks('old.md', makeTaskNote({ path: 'old.md' }));
+			cache.renameFile('old.md', 'new.md');
+
+			expect(cache.getFileTasks('old.md')).toBeNull();
+			const renamed = cache.getFileTasks('new.md');
+			expect(renamed).not.toBeNull();
+			expect(renamed!.path).toBe('new.md');
+		});
+
+		it('no-op if old path not in cache', () => {
+			cache.renameFile('nonexistent.md', 'new.md');
+			expect(cache.getFileTasks('new.md')).toBeNull();
+		});
+	});
+
+	describe('getAllCachedTasks', () => {
+		it('returns all TaskNotes as array', () => {
+			cache.setFileTasks('a.md', makeTaskNote({ title: 'A' }));
+			cache.setFileTasks('b.md', makeTaskNote({ title: 'B' }));
+			cache.setFileTasks('c.md', makeTaskNote({ title: 'C' }));
+
+			const all = cache.getAllCachedTasks();
+			expect(all).toHaveLength(3);
+			expect(all.map(t => t.title).sort()).toEqual(['A', 'B', 'C']);
+		});
+	});
+
+	describe('invalidateFile / isFileDirty', () => {
+		it('marks file as dirty', () => {
+			cache.setFileTasks('a.md', makeTaskNote());
+			expect(cache.isFileDirty('a.md')).toBe(false);
+
+			cache.invalidateFile('a.md');
+			expect(cache.isFileDirty('a.md')).toBe(true);
+		});
+	});
+
+	describe('clearCache', () => {
+		it('removes all entries and dirty flags', () => {
+			cache.setFileTasks('a.md', makeTaskNote());
+			cache.invalidateFile('a.md');
+			cache.clearCache();
+
+			expect(cache.isEmpty()).toBe(true);
+			expect(cache.isFileDirty('a.md')).toBe(false);
+		});
+	});
+
+	describe('getStats', () => {
+		it('returns correct counts', () => {
+			cache.setFileTasks('a.md', makeTaskNote());
+			cache.setFileTasks('b.md', makeTaskNote());
+
+			const stats = cache.getStats();
+			expect(stats.cachedFiles).toBe(2);
+			expect(stats.totalTasks).toBe(2);
+			expect(stats.memoryEstimate).toBeGreaterThan(0);
+		});
+
+		it('returns zeros when empty', () => {
+			const stats = cache.getStats();
+			expect(stats.cachedFiles).toBe(0);
+			expect(stats.totalTasks).toBe(0);
+			expect(stats.memoryEstimate).toBe(0);
+		});
+	});
+});

--- a/src/__tests__/taskNoteParser.test.ts
+++ b/src/__tests__/taskNoteParser.test.ts
@@ -64,8 +64,15 @@ describe('parseTaskNoteFromFrontmatter', () => {
 		expect(parseTaskNoteFromFrontmatter(undefined, filePath)).toBeNull();
 	});
 
-	it('returns null when title is missing', () => {
-		expect(parseTaskNoteFromFrontmatter({ status: 'open', recurrence: 'FREQ=DAILY' }, filePath)).toBeNull();
+	it('returns null when both title and recurrence are missing', () => {
+		expect(parseTaskNoteFromFrontmatter({ status: 'open' }, filePath)).toBeNull();
+	});
+
+	it('derives title from file path when title is missing but recurrence exists', () => {
+		const result = parseTaskNoteFromFrontmatter({ recurrence: 'FREQ=DAILY' }, 'tasks/morning-workout.md');
+		expect(result).not.toBeNull();
+		expect(result!.title).toBe('morning-workout');
+		expect(result!.recurrence).toBe('FREQ=DAILY');
 	});
 
 	it('coerces YAML Date objects in complete_instances to strings', () => {

--- a/src/__tests__/tasksApi.test.ts
+++ b/src/__tests__/tasksApi.test.ts
@@ -1,0 +1,97 @@
+import { TasksApiWrapper } from '../tasksApi';
+import { TaskNote } from '../types';
+
+function makeTaskNote(overrides: Partial<TaskNote> = {}): TaskNote {
+	return {
+		title: 'Test task',
+		status: 'open',
+		recurrence: 'FREQ=DAILY',
+		recurrenceAnchor: 'scheduled',
+		tags: ['habit'],
+		path: 'tasks/test.md',
+		completeInstances: [],
+		skippedInstances: [],
+		...overrides
+	};
+}
+
+describe('TasksApiWrapper', () => {
+	let api: TasksApiWrapper;
+
+	beforeEach(() => {
+		// Construct with a minimal mock App (only metadataCache and vault needed for fallback)
+		api = new TasksApiWrapper({} as any);
+	});
+
+	describe('getCompletionHistory', () => {
+		it('parses completeInstances as sorted Date array', () => {
+			const task = makeTaskNote({
+				completeInstances: ['2025-01-17', '2025-01-15', '2025-01-16']
+			});
+
+			const dates = api.getCompletionHistory(task);
+
+			expect(dates).toHaveLength(3);
+			expect(dates[0].getUTCFullYear()).toBe(2025);
+			expect(dates[0].getUTCMonth()).toBe(0); // January
+			expect(dates[0].getUTCDate()).toBe(15);
+			expect(dates[1].getUTCDate()).toBe(16);
+			expect(dates[2].getUTCDate()).toBe(17);
+		});
+
+		it('returns empty array for no completeInstances', () => {
+			const task = makeTaskNote({ completeInstances: [] });
+			expect(api.getCompletionHistory(task)).toEqual([]);
+		});
+
+		it('handles single completion date', () => {
+			const task = makeTaskNote({ completeInstances: ['2025-03-01'] });
+			const dates = api.getCompletionHistory(task);
+
+			expect(dates).toHaveLength(1);
+			expect(dates[0].getUTCDate()).toBe(1);
+			expect(dates[0].getUTCMonth()).toBe(2); // March
+		});
+	});
+
+	describe('getHabitTaskNotes (via getAllTaskNotes)', () => {
+		it('filters by tag and recurrence', async () => {
+			const tasks: TaskNote[] = [
+				makeTaskNote({ title: 'Workout', tags: ['habit'], recurrence: 'FREQ=DAILY' }),
+				makeTaskNote({ title: 'No tag', tags: [], recurrence: 'FREQ=DAILY' }),
+				makeTaskNote({ title: 'No recurrence', tags: ['habit'], recurrence: '' }),
+				makeTaskNote({ title: 'Reading', tags: ['habit', 'learning'], recurrence: 'FREQ=WEEKLY' }),
+			];
+
+			// Mock plugin with getCachedTaskNotes
+			api.setPlugin({
+				getCachedTaskNotes: async () => tasks
+			});
+
+			const habits = await api.getHabitTaskNotes('habit');
+
+			expect(habits).toHaveLength(2);
+			expect(habits.map(t => t.title).sort()).toEqual(['Reading', 'Workout']);
+		});
+
+		it('filters by custom tag', async () => {
+			const tasks: TaskNote[] = [
+				makeTaskNote({ title: 'A', tags: ['custom'], recurrence: 'FREQ=DAILY' }),
+				makeTaskNote({ title: 'B', tags: ['habit'], recurrence: 'FREQ=DAILY' }),
+			];
+
+			api.setPlugin({ getCachedTaskNotes: async () => tasks });
+
+			const habits = await api.getHabitTaskNotes('custom');
+			expect(habits).toHaveLength(1);
+			expect(habits[0].title).toBe('A');
+		});
+
+		it('returns empty array when no habits match', async () => {
+			api.setPlugin({ getCachedTaskNotes: async () => [] });
+
+			const habits = await api.getHabitTaskNotes('habit');
+			expect(habits).toEqual([]);
+		});
+	});
+});

--- a/src/cache/TaskCacheManager.ts
+++ b/src/cache/TaskCacheManager.ts
@@ -1,8 +1,5 @@
-import { TaskInfo } from '../types';
+import { TaskNote } from '../types';
 
-/**
- * Cache statistics for monitoring performance and memory usage.
- */
 export interface CacheStats {
 	cachedFiles: number;
 	totalTasks: number;
@@ -10,130 +7,78 @@ export interface CacheStats {
 }
 
 /**
- * Manages in-memory caching of parsed tasks with event-driven invalidation.
+ * Manages in-memory caching of parsed TaskNotes with event-driven invalidation.
  *
  * Cache strategy:
- * - Map<filePath, TaskInfo[]> for O(1) file lookups
- * - Lazy initialization (populated on first getAllTasks call)
+ * - Map<filePath, TaskNote> for O(1) file lookups (one TaskNote per file)
+ * - Lazy initialization (populated on first access)
  * - Invalidation on file modify/delete/rename events
  * - Memory-based (cleared on plugin unload)
  */
 export class TaskCacheManager {
-	private cache: Map<string, TaskInfo[]> = new Map();
-	private isDirty: Set<string> = new Set(); // Files needing re-parse
+	private cache: Map<string, TaskNote> = new Map();
+	private isDirty: Set<string> = new Set();
 
-	/**
-	 * Check if cache is empty (not yet initialized).
-	 */
 	isEmpty(): boolean {
 		return this.cache.size === 0;
 	}
 
-	/**
-	 * Get cached tasks for a specific file.
-	 * Returns null if file not in cache.
-	 */
-	getFileTasks(filePath: string): TaskInfo[] | null {
+	getFileTasks(filePath: string): TaskNote | null {
 		return this.cache.get(filePath) ?? null;
 	}
 
-	/**
-	 * Set/update tasks for a specific file.
-	 */
-	setFileTasks(filePath: string, tasks: TaskInfo[]): void {
-		this.cache.set(filePath, tasks);
-		this.isDirty.delete(filePath); // Mark as clean
+	setFileTasks(filePath: string, task: TaskNote): void {
+		this.cache.set(filePath, task);
+		this.isDirty.delete(filePath);
 	}
 
-	/**
-	 * Bulk set tasks from multiple files (used for initial population).
-	 */
-	bulkSet(tasksByFile: Map<string, TaskInfo[]>): void {
+	bulkSet(tasksByFile: Map<string, TaskNote>): void {
 		this.cache.clear();
 		this.isDirty.clear();
-		for (const [filePath, tasks] of tasksByFile.entries()) {
-			this.cache.set(filePath, tasks);
+		for (const [filePath, task] of tasksByFile.entries()) {
+			this.cache.set(filePath, task);
 		}
 	}
 
-	/**
-	 * Mark a file as needing re-parsing (dirty).
-	 * The file stays in cache but will be re-parsed on next access if needed.
-	 */
 	invalidateFile(filePath: string): void {
 		this.isDirty.add(filePath);
 	}
 
-	/**
-	 * Remove a file from the cache entirely (used for delete events).
-	 */
 	removeFile(filePath: string): void {
 		this.cache.delete(filePath);
 		this.isDirty.delete(filePath);
 	}
 
-	/**
-	 * Rename a file in the cache (used for rename events).
-	 */
 	renameFile(oldPath: string, newPath: string): void {
-		const tasks = this.cache.get(oldPath);
-		if (tasks) {
-			// Update file paths in task objects
-			const updatedTasks = tasks.map(task => ({
-				...task,
-				path: newPath
-			}));
+		const task = this.cache.get(oldPath);
+		if (task) {
 			this.cache.delete(oldPath);
-			this.cache.set(newPath, updatedTasks);
+			this.cache.set(newPath, { ...task, path: newPath });
 			this.isDirty.delete(oldPath);
 		}
 	}
 
-	/**
-	 * Get all cached tasks from all files.
-	 */
-	getAllCachedTasks(): TaskInfo[] {
-		const allTasks: TaskInfo[] = [];
-		for (const tasks of this.cache.values()) {
-			allTasks.push(...tasks);
-		}
-		return allTasks;
+	getAllCachedTasks(): TaskNote[] {
+		return Array.from(this.cache.values());
 	}
 
-	/**
-	 * Clear the entire cache.
-	 */
 	clearCache(): void {
 		this.cache.clear();
 		this.isDirty.clear();
 	}
 
-	/**
-	 * Get cache statistics for monitoring.
-	 */
 	getStats(): CacheStats {
 		const cachedFiles = this.cache.size;
-		let totalTasks = 0;
-
-		for (const tasks of this.cache.values()) {
-			totalTasks += tasks.length;
-		}
-
-		// Estimate memory usage:
-		// Each TaskInfo ~ 200 bytes (strings + metadata)
-		// Each Map entry ~ 50 bytes overhead
-		const memoryEstimate = (totalTasks * 200) + (cachedFiles * 50);
+		// One TaskNote per file; ~400 bytes each (strings + instance arrays)
+		const memoryEstimate = (cachedFiles * 400) + (cachedFiles * 50);
 
 		return {
 			cachedFiles,
-			totalTasks,
+			totalTasks: cachedFiles,
 			memoryEstimate
 		};
 	}
 
-	/**
-	 * Check if a file is marked dirty (needs re-parsing).
-	 */
 	isFileDirty(filePath: string): boolean {
 		return this.isDirty.has(filePath);
 	}

--- a/src/events/VaultEventHandler.ts
+++ b/src/events/VaultEventHandler.ts
@@ -1,50 +1,38 @@
-import { Plugin, TFile } from 'obsidian';
+import { App, Plugin, TFile } from 'obsidian';
 import { TaskCacheManager } from '../cache/TaskCacheManager';
-import { parseTasksFromFile } from '../utils/taskParser';
+import { parseTaskNoteFromFile } from '../utils/taskParser';
 
 /**
  * Handles Obsidian vault events to keep the task cache synchronized.
  *
  * Events handled:
- * - create: New markdown file created
- * - modify: Markdown file content changed
- * - delete: File removed from vault
- * - rename: File path changed
+ * - metadataCache changed: File frontmatter updated (create or modify)
+ * - vault delete: File removed from vault
+ * - vault rename: File path changed
  *
- * All event handlers are registered via plugin.registerEvent() for automatic cleanup.
+ * Uses metadataCache.on('changed') instead of vault.on('modify') to ensure
+ * frontmatter is fully parsed before we read it.
  */
 export class VaultEventHandler {
 	constructor(
 		private plugin: Plugin,
-		private cacheManager: TaskCacheManager
+		private cacheManager: TaskCacheManager,
+		private app: App
 	) {}
 
-	/**
-	 * Setup all vault event listeners.
-	 * Must be called during plugin onload().
-	 */
 	setupEventListeners(): void {
-		const { vault } = this.plugin.app;
+		const { vault, metadataCache } = this.app;
 
-		// Handle file creation - parse and cache immediately
+		// Handle file content changes via MetadataCache (fires after frontmatter is parsed)
 		this.plugin.registerEvent(
-			vault.on('create', async (file) => {
+			metadataCache.on('changed', (file) => {
 				if (file instanceof TFile && file.extension === 'md') {
-					await this.handleCreate(file);
+					this.handleChanged(file);
 				}
 			})
 		);
 
-		// Handle file modification - re-parse and update cache
-		this.plugin.registerEvent(
-			vault.on('modify', async (file) => {
-				if (file instanceof TFile && file.extension === 'md') {
-					await this.handleModify(file);
-				}
-			})
-		);
-
-		// Handle file deletion - remove from cache
+		// Handle file deletion
 		this.plugin.registerEvent(
 			vault.on('delete', (file) => {
 				if (file instanceof TFile && file.extension === 'md') {
@@ -53,7 +41,7 @@ export class VaultEventHandler {
 			})
 		);
 
-		// Handle file rename - update cache with new path
+		// Handle file rename
 		this.plugin.registerEvent(
 			vault.on('rename', (file, oldPath) => {
 				if (file instanceof TFile && file.extension === 'md') {
@@ -63,46 +51,19 @@ export class VaultEventHandler {
 		);
 	}
 
-	/**
-	 * Handle new file creation.
-	 * Parse the new file and add to cache if it contains tasks.
-	 */
-	private async handleCreate(file: TFile): Promise<void> {
-		try {
-			const tasks = await parseTasksFromFile(this.plugin.app.vault, file);
-			this.cacheManager.setFileTasks(file.path, tasks);
-		} catch (error) {
-			console.error(`[habits-graph] Error parsing new file ${file.path}:`, error);
+	private handleChanged(file: TFile): void {
+		const taskNote = parseTaskNoteFromFile(this.app.metadataCache, file);
+		if (taskNote) {
+			this.cacheManager.setFileTasks(file.path, taskNote);
+		} else {
+			this.cacheManager.removeFile(file.path);
 		}
 	}
 
-	/**
-	 * Handle file modification.
-	 * Re-parse the file and update cache.
-	 */
-	private async handleModify(file: TFile): Promise<void> {
-		try {
-			const tasks = await parseTasksFromFile(this.plugin.app.vault, file);
-			this.cacheManager.setFileTasks(file.path, tasks);
-		} catch (error) {
-			console.error(`[habits-graph] Error re-parsing modified file ${file.path}:`, error);
-			// Mark as dirty so it gets re-parsed on next access
-			this.cacheManager.invalidateFile(file.path);
-		}
-	}
-
-	/**
-	 * Handle file deletion.
-	 * Remove file from cache entirely.
-	 */
 	private handleDelete(file: TFile): void {
 		this.cacheManager.removeFile(file.path);
 	}
 
-	/**
-	 * Handle file rename.
-	 * Update cache to reflect new file path.
-	 */
 	private handleRename(file: TFile, oldPath: string): void {
 		this.cacheManager.renameFile(oldPath, file.path);
 	}

--- a/src/habitGraphView.ts
+++ b/src/habitGraphView.ts
@@ -1,7 +1,6 @@
 import { ItemView, WorkspaceLeaf } from 'obsidian';
 import type OrgHabitsGraphPlugin from './main';
 import { GraphRenderer } from './graphRenderer';
-import { formatISODate } from './utils/dateUtils';
 
 export const VIEW_TYPE_HABIT_GRAPH = 'habit-graph-view';
 
@@ -37,14 +36,7 @@ export class HabitGraphView extends ItemView {
 		const container = this.containerEl.children[1];
 		container.empty();
 
-		// Check if Tasks plugin is available
-		if (!this.plugin.tasksApi.isTasksPluginAvailable()) {
-			this.renderError(container, 'Tasks plugin is required but not found. Please install and enable the Tasks plugin.');
-			return;
-		}
-
-		// Get habit tasks
-		const habitTasks = await this.plugin.tasksApi.getHabitTasks(
+		const habitTasks = await this.plugin.tasksApi.getHabitTaskNotes(
 			this.plugin.settings.habitTag
 		);
 
@@ -53,36 +45,22 @@ export class HabitGraphView extends ItemView {
 			return;
 		}
 
-		// Group by unique habit
-		const habits = this.plugin.tasksApi.getUniqueHabits(habitTasks);
+		for (const task of habitTasks) {
+			const completionDates = this.plugin.tasksApi.getCompletionHistory(task);
 
-		// Render each habit graph
-		for (const [description, tasks] of habits) {
-			// Get the most recent task info for this habit
-			const currentTask = tasks.find(t => !t.completed) || tasks[tasks.length - 1];
-
-			// Get completion history
-			const completionDates = this.plugin.tasksApi.getCompletionHistory(
-				tasks,
-				description
-			);
-
-			// Generate day cells with recurrence pattern for scheduling window
 			const cells = GraphRenderer.generateDayCells(
 				completionDates,
 				this.plugin.settings.daysBeforeToday,
 				this.plugin.settings.daysAfterToday,
-				currentTask.recurrence
+				task.recurrence
 			);
 
-			// Calculate streak
 			const streak = GraphRenderer.calculateStreak(completionDates);
 
-			// Render graph
 			const graphEl = GraphRenderer.renderGraph(
 				cells,
-				description,
-				currentTask.recurrence,
+				task.title,
+				task.recurrence,
 				streak,
 				this.plugin.settings.showStreakCount
 			);
@@ -91,35 +69,24 @@ export class HabitGraphView extends ItemView {
 		}
 	}
 
-	private renderError(container: Element, message: string): void {
-		container.empty();
-		const errorEl = container.createDiv({ cls: 'habit-graph-error' });
-		errorEl.createEl('h3', { text: '⚠️ Error' });
-		errorEl.createEl('p', { text: message });
-
-		const link = errorEl.createEl('a', {
-			text: 'Install Tasks plugin',
-			href: 'obsidian://show-plugin?id=obsidian-tasks-plugin'
-		});
-		link.onclick = (e) => {
-			e.preventDefault();
-			// @ts-ignore
-			this.app.commands.executeCommandById('obsidian://show-plugin?id=obsidian-tasks-plugin');
-		};
-	}
-
 	private renderEmpty(container: Element): void {
 		container.empty();
 		const emptyEl = container.createDiv({ cls: 'habit-graph-empty' });
 		emptyEl.createEl('h3', { text: 'No habits found' });
 		emptyEl.createEl('p', {
-			text: `Create recurring tasks with #${this.plugin.settings.habitTag} tag to track habits.`
+			text: `Create markdown files with frontmatter containing tags: [${this.plugin.settings.habitTag}] and a recurrence field.`
 		});
 
+		const tag = this.plugin.settings.habitTag;
 		const example = emptyEl.createEl('pre');
-		example.textContent = `Example:
-- [ ] Morning workout 🔁 every day #${this.plugin.settings.habitTag} 📅 2025-01-18
-- [ ] Bible reading 🔁 every day #${this.plugin.settings.habitTag} 📅 2025-01-18
-- [ ] Guitar practice 🔁 every week #${this.plugin.settings.habitTag} 📅 2025-01-20`;
+		example.textContent = `Example frontmatter:
+---
+title: Morning workout
+recurrence: FREQ=DAILY
+tags: [${tag}]
+complete_instances:
+  - 2025-01-15
+  - 2025-01-16
+---`;
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,14 +27,8 @@ export default class OrgHabitsGraphPlugin extends Plugin {
 		this.fileOrganizer = new FileOrganizer(this.app.vault);
 
 		// Setup vault event handlers for cache invalidation
-		this.eventHandler = new VaultEventHandler(this, this.cacheManager);
+		this.eventHandler = new VaultEventHandler(this, this.cacheManager, this.app);
 		this.eventHandler.setupEventListeners();
-
-		// Check if Tasks plugin is available
-		if (!this.tasksApi.isTasksPluginAvailable()) {
-			new Notice('⚠️ Org Habits Graph requires the Tasks plugin.\nPlease install and enable it first.', 10000);
-			// Don't return - still register the view so user can see error message
-		}
 
 		// Register the habit graph view
 		this.registerView(
@@ -142,20 +136,13 @@ export default class OrgHabitsGraphPlugin extends Plugin {
 		this.cacheManager.clearCache();
 	}
 
-	/**
-	 * Get all tasks with caching.
-	 * Uses cache-first approach with lazy initialization.
-	 * Event handlers keep cache synchronized with file changes.
-	 */
-	async getCachedTasks() {
-		// Lazy initialization: populate cache on first call
+	async getCachedTaskNotes() {
 		if (this.cacheManager.isEmpty()) {
-			const { parseTasksFromAllFiles } = await import('./utils/taskParser');
-			const tasksByFile = await parseTasksFromAllFiles(this.app.vault);
+			const { parseTaskNotesFromAllFiles } = await import('./utils/taskParser');
+			const tasksByFile = parseTaskNotesFromAllFiles(this.app.vault, this.app.metadataCache);
 			this.cacheManager.bulkSet(tasksByFile);
 		}
 
-		// Return all cached tasks (O(1) operation after initialization)
 		return this.cacheManager.getAllCachedTasks();
 	}
 
@@ -209,20 +196,11 @@ export default class OrgHabitsGraphPlugin extends Plugin {
 	 * Render habit graph in a code block
 	 */
 	async renderHabitGraphCodeBlock(
-		source: string,
+		_source: string,
 		el: HTMLElement,
-		ctx: MarkdownPostProcessorContext
+		_ctx: MarkdownPostProcessorContext
 	): Promise<void> {
-		// Check if Tasks plugin is available
-		if (!this.tasksApi.isTasksPluginAvailable()) {
-			const errorEl = el.createDiv({ cls: 'habit-graph-error' });
-			errorEl.createEl('h3', { text: '⚠️ Error' });
-			errorEl.createEl('p', { text: 'Tasks plugin is required but not found. Please install and enable the Tasks plugin.' });
-			return;
-		}
-
-		// Get habit tasks
-		const habitTasks = await this.tasksApi.getHabitTasks(
+		const habitTasks = await this.tasksApi.getHabitTaskNotes(
 			this.settings.habitTag
 		);
 
@@ -230,41 +208,27 @@ export default class OrgHabitsGraphPlugin extends Plugin {
 			const emptyEl = el.createDiv({ cls: 'habit-graph-empty' });
 			emptyEl.createEl('h3', { text: 'No habits found' });
 			emptyEl.createEl('p', {
-				text: `Create recurring tasks with #${this.settings.habitTag} tag to track habits.`
+				text: `Create markdown files with frontmatter containing tags: [${this.settings.habitTag}] and a recurrence field.`
 			});
 			return;
 		}
 
-		// Group by unique habit
-		const habits = this.tasksApi.getUniqueHabits(habitTasks);
+		for (const task of habitTasks) {
+			const completionDates = this.tasksApi.getCompletionHistory(task);
 
-		// Render each habit graph
-		for (const [description, tasks] of habits) {
-			// Get the most recent task info for this habit
-			const currentTask = tasks.find(t => !t.completed) || tasks[tasks.length - 1];
-
-			// Get completion history
-			const completionDates = this.tasksApi.getCompletionHistory(
-				tasks,
-				description
-			);
-
-			// Generate day cells with recurrence pattern for scheduling window
 			const cells = GraphRenderer.generateDayCells(
 				completionDates,
 				this.settings.daysBeforeToday,
 				this.settings.daysAfterToday,
-				currentTask.recurrence
+				task.recurrence
 			);
 
-			// Calculate streak
 			const streak = GraphRenderer.calculateStreak(completionDates);
 
-			// Render graph
 			const graphEl = GraphRenderer.renderGraph(
 				cells,
-				description,
-				currentTask.recurrence,
+				task.title,
+				task.recurrence,
 				streak,
 				this.settings.showStreakCount
 			);

--- a/src/tasksApi.ts
+++ b/src/tasksApi.ts
@@ -1,90 +1,37 @@
 import { App } from 'obsidian';
 import { parseISODate } from './utils/dateUtils';
-import { parseTasksFromContent, parseTasksFromAllFiles } from './utils/taskParser';
-import { TaskInfo } from './types';
+import { parseTaskNotesFromAllFiles } from './utils/taskParser';
+import { TaskNote } from './types';
 
 export class TasksApiWrapper {
-	private plugin?: any; // Reference to plugin for cache access
+	private plugin?: any;
 
 	constructor(private app: App) {}
 
-	/**
-	 * Set plugin reference for cache access.
-	 * This enables cached task retrieval.
-	 */
 	setPlugin(plugin: any): void {
 		this.plugin = plugin;
 	}
 
-	getTasksPlugin(): any {
-		return (this.app as any).plugins.getPlugin('obsidian-tasks-plugin');
-	}
-
-	isTasksPluginAvailable(): boolean {
-		const plugin = this.getTasksPlugin();
-		return plugin !== null && plugin !== undefined;
-	}
-
-	/**
-	 * Get all tasks from all markdown files in the vault.
-	 * Uses cache if plugin reference is set, otherwise parses all files.
-	 */
-	async getAllTasks(): Promise<TaskInfo[]> {
-		// Use cached version if plugin is available
-		if (this.plugin && typeof this.plugin.getCachedTasks === 'function') {
-			return await this.plugin.getCachedTasks();
+	async getAllTaskNotes(): Promise<TaskNote[]> {
+		if (this.plugin && typeof this.plugin.getCachedTaskNotes === 'function') {
+			return await this.plugin.getCachedTaskNotes();
 		}
 
 		// Fallback: parse all files (no caching)
-		const tasksByFile = await parseTasksFromAllFiles(this.app.vault);
-		const allTasks: TaskInfo[] = [];
-
-		for (const tasks of tasksByFile.values()) {
-			allTasks.push(...tasks);
-		}
-
-		return allTasks;
+		const tasksByFile = parseTaskNotesFromAllFiles(this.app.vault, this.app.metadataCache);
+		return Array.from(tasksByFile.values());
 	}
 
-	/**
-	 * Get all habit tasks (recurring tasks with habit tag)
-	 */
-	async getHabitTasks(habitTag: string = 'habit'): Promise<TaskInfo[]> {
-		const allTasks = await this.getAllTasks();
+	async getHabitTaskNotes(habitTag: string = 'habit'): Promise<TaskNote[]> {
+		const allTasks = await this.getAllTaskNotes();
 		return allTasks.filter(task =>
 			task.recurrence && task.tags.includes(habitTag)
 		);
 	}
 
-	/**
-	 * Group completed instances of the same habit.
-	 *
-	 * Parses completion dates using UTC-aware parseISODate to ensure
-	 * consistent date handling across timezones.
-	 */
-	getCompletionHistory(tasks: TaskInfo[], habitDescription: string): Date[] {
-		return tasks
-			.filter(task =>
-				task.description === habitDescription &&
-				task.completed &&
-				task.completedDate
-			)
-			.map(task => parseISODate(task.completedDate!))
+	getCompletionHistory(task: TaskNote): Date[] {
+		return task.completeInstances
+			.map(dateStr => parseISODate(dateStr))
 			.sort((a, b) => a.getTime() - b.getTime());
-	}
-
-	/**
-	 * Get unique habit descriptions (deduplicated)
-	 */
-	getUniqueHabits(tasks: TaskInfo[]): Map<string, TaskInfo[]> {
-		const habitMap = new Map<string, TaskInfo[]>();
-
-		for (const task of tasks) {
-			const existing = habitMap.get(task.description) || [];
-			existing.push(task);
-			habitMap.set(task.description, existing);
-		}
-
-		return habitMap;
 	}
 }

--- a/src/utils/taskParser.ts
+++ b/src/utils/taskParser.ts
@@ -181,11 +181,18 @@ function pick<T>(fm: Record<string, unknown>, ...keys: string[]): T | undefined 
 	return undefined;
 }
 
+function titleFromPath(filePath: string): string {
+	const basename = filePath.split('/').pop() ?? filePath;
+	return basename.replace(/\.md$/i, '');
+}
+
 export function parseTaskNoteFromFrontmatter(
 	frontmatter: Record<string, unknown> | null | undefined,
 	filePath: string
 ): TaskNote | null {
-	if (!frontmatter || !frontmatter['title']) return null;
+	if (!frontmatter) return null;
+	// A TaskNote must have either a title or a recurrence field
+	if (!frontmatter['title'] && !frontmatter['recurrence']) return null;
 
 	const recurrenceAnchorRaw = pick<string>(frontmatter, 'recurrence_anchor', 'recurrenceAnchor');
 	const recurrenceAnchor: 'scheduled' | 'completion' =
@@ -193,7 +200,7 @@ export function parseTaskNoteFromFrontmatter(
 
 	return {
 		id: frontmatter['id'] != null ? String(frontmatter['id']) : undefined,
-		title: String(frontmatter['title']),
+		title: frontmatter['title'] != null ? String(frontmatter['title']) : titleFromPath(filePath),
 		status: frontmatter['status'] != null ? String(frontmatter['status']) : 'open',
 		recurrence: frontmatter['recurrence'] != null ? String(frontmatter['recurrence']) : '',
 		recurrenceAnchor,


### PR DESCRIPTION
## Summary

- **TaskCacheManager**: `Map<string, TaskInfo[]>` → `Map<string, TaskNote>` (one task per file, no array spreading)
- **VaultEventHandler**: Switched from `vault.on('modify')` to `metadataCache.on('changed')` for reliable frontmatter reads; uses `parseTaskNoteFromFile`
- **TasksApiWrapper**: Removed Tasks plugin dependency (`getTasksPlugin`, `isTasksPluginAvailable`, `getUniqueHabits`); simplified `getCompletionHistory` to read `completeInstances` directly
- **HabitGraphView + main.ts**: Iterate `TaskNote[]` directly (no grouping), use `task.title`, updated empty-state examples to frontmatter format
- 22 new unit tests (15 cache manager, 7 API wrapper); 69 total passing

Old `TaskInfo` type and parsers remain in codebase for removal in #19.

Closes #18

## Test plan

- [x] `npm run build` — clean production build
- [x] `npx tsc --noEmit` — clean type check
- [x] `npm test` — 69/69 tests pass (47 existing + 22 new)
- [x] Manual: load plugin in Obsidian vault with TaskNote-format habit files, verify graphs render
- [x] Manual: verify cache updates on file create/modify/delete/rename