### PR TITLE
Render habit graph as SVG for mobile legibility

### DIFF
--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -109,144 +109,94 @@ export class GraphRenderer {
 		return cells;
 	}
 
-	/**
-	 * Render the graph as HTML (org-mode style)
-	 */
 	static renderGraph(
 		cells: DayCell[],
 		habitName: string,
-		recurrence: string,
 		streak: number,
 		showStreak: boolean
 	): HTMLElement {
 		const container = document.createElement('div');
 		container.className = 'habit-graph-row';
 
-		// Left side: Habit label (strip #habit tag)
 		const labelContainer = container.createDiv({ cls: 'habit-label' });
 		const cleanName = habitName.replace(/#habit/g, '').trim();
 		labelContainer.textContent = cleanName;
 
-		// Display streak count if enabled
 		if (showStreak && streak > 0) {
 			const streakEl = labelContainer.createSpan({ cls: 'habit-streak' });
 			streakEl.textContent = ` 🔥${streak}`;
 		}
 
-		// Right side: Wrapper for scrollable graph
-		const graphWrapper = container.createDiv({ cls: 'habit-graph-wrapper' });
+		const svgNS = 'http://www.w3.org/2000/svg';
+		const svg = document.createElementNS(svgNS, 'svg');
+		svg.setAttribute('class', 'habit-graph-svg');
+		svg.setAttribute('width', '100%');
+		svg.setAttribute('height', '20');
 
-		// Manual drag scrolling to override Obsidian's gesture system
-		let isDragging = false;
-		let startX = 0;
-		let startY = 0;
-		let scrollLeft = 0;
-		let isHorizontalScroll = false;
+		const cellCount = cells.length;
+		const cellWidthPct = 100 / cellCount;
 
-		graphWrapper.addEventListener('touchstart', (e) => {
-			isDragging = true;
-			startX = e.touches[0].pageX;
-			startY = e.touches[0].pageY;
-			scrollLeft = graphWrapper.scrollLeft;
-			isHorizontalScroll = false;
-		}, { passive: true });
+		for (let i = 0; i < cellCount; i++) {
+			const cell = cells[i];
 
-		graphWrapper.addEventListener('touchmove', (e) => {
-			if (!isDragging) return;
-
-			const touch = e.touches[0];
-			const deltaX = touch.pageX - startX;
-			const deltaY = touch.pageY - startY;
-
-			// Determine if this is a horizontal scroll on first move
-			if (!isHorizontalScroll && (Math.abs(deltaX) > 5 || Math.abs(deltaY) > 5)) {
-				isHorizontalScroll = Math.abs(deltaX) > Math.abs(deltaY);
-			}
-
-			// If horizontal scrolling, prevent default and manually scroll
-			if (isHorizontalScroll) {
-				e.preventDefault();
-				e.stopPropagation();
-				graphWrapper.scrollLeft = scrollLeft - deltaX;
-			}
-		}, { passive: false });
-
-		graphWrapper.addEventListener('touchend', () => {
-			isDragging = false;
-			isHorizontalScroll = false;
-		}, { passive: true });
-
-		graphWrapper.addEventListener('touchcancel', () => {
-			isDragging = false;
-			isHorizontalScroll = false;
-		}, { passive: true });
-
-		const graphContainer = graphWrapper.createDiv({ cls: 'habit-graph' });
-
-		for (const cell of cells) {
-			const dayEl = graphContainer.createDiv({ cls: 'habit-day' });
-
-			// Determine color based on org-mode rules with scheduling window
 			let colorClass = '';
 			switch (cell.status) {
-				case 'done':
-					colorClass = 'green';
-					break;
-				case 'missed':
-					colorClass = 'red';
-					break;
-				case 'skipped':
-					colorClass = 'gray';
-					break;
-				case 'rest':
-					colorClass = 'blue';
-					break;
-				case 'future-too-early':
-					colorClass = 'blue';
-					break;
-				case 'future-ok':
-					colorClass = 'green-light';
-					break;
-				case 'future-warning':
-					colorClass = 'yellow';
-					break;
-				case 'future-overdue':
-					colorClass = 'red';
-					break;
-				case 'today-done':
-					colorClass = 'green';
-					break;
-				case 'today-missed':
-					colorClass = 'yellow';
-					break;
+				case 'done': colorClass = 'green'; break;
+				case 'missed': colorClass = 'red'; break;
+				case 'skipped': colorClass = 'gray'; break;
+				case 'rest': colorClass = 'blue'; break;
+				case 'future-too-early': colorClass = 'blue'; break;
+				case 'future-ok': colorClass = 'green-light'; break;
+				case 'future-warning': colorClass = 'yellow'; break;
+				case 'future-overdue': colorClass = 'red'; break;
+				case 'today-done': colorClass = 'green'; break;
+				case 'today-missed': colorClass = 'yellow'; break;
 			}
 
+			const g = document.createElementNS(svgNS, 'g');
 			if (colorClass) {
-				dayEl.addClass(colorClass);
+				g.setAttribute('class', colorClass);
 			}
 
-			// Add asterisk for completed days
-			if (cell.completed) {
-				dayEl.textContent = '*';
-			} else if (cell.status === 'skipped') {
-				dayEl.textContent = '~';
-			}
+			const rect = document.createElementNS(svgNS, 'rect');
+			rect.setAttribute('x', `${cellWidthPct * i}%`);
+			rect.setAttribute('y', '0');
+			rect.setAttribute('width', `${cellWidthPct}%`);
+			rect.setAttribute('height', '20');
+			g.appendChild(rect);
 
-			// Add exclamation mark for today
+			let marker = '';
 			if (cell.isToday) {
-				const todayMarker = dayEl.createSpan({ cls: 'today-indicator' });
-				todayMarker.textContent = cell.completed ? '*!' : '!';
-				dayEl.textContent = '';
-				dayEl.appendChild(todayMarker);
+				marker = cell.completed ? '*!' : '!';
+			} else if (cell.completed) {
+				marker = '*';
+			} else if (cell.status === 'skipped') {
+				marker = '~';
 			}
 
-			// Tooltip
+			if (marker) {
+				const text = document.createElementNS(svgNS, 'text');
+				text.setAttribute('x', `${cellWidthPct * i + cellWidthPct / 2}%`);
+				text.setAttribute('y', '10');
+				text.setAttribute('text-anchor', 'middle');
+				text.setAttribute('dominant-baseline', 'central');
+				text.setAttribute('font-size', '10');
+				text.setAttribute('font-weight', 'bold');
+				text.textContent = marker;
+				g.appendChild(text);
+			}
+
+			const title = document.createElementNS(svgNS, 'title');
 			const dateStr = this.dateToString(cell.date);
 			const dayName = cell.date.toLocaleDateString('en-US', { weekday: 'short' });
 			const statusText = cell.completed ? 'Done' : cell.status === 'skipped' ? 'Skipped' : (cell.status === 'rest' || cell.isFuture) ? 'Not due' : 'Missed';
-			dayEl.setAttribute('title', `${dayName} ${dateStr}: ${statusText}`);
+			title.textContent = `${dayName} ${dateStr}: ${statusText}`;
+			g.appendChild(title);
+
+			svg.appendChild(g);
 		}
 
+		container.appendChild(svg);
 		return container;
 	}
 

--- a/src/habitGraphView.ts
+++ b/src/habitGraphView.ts
@@ -62,7 +62,6 @@ export class HabitGraphView extends ItemView {
 			const graphEl = GraphRenderer.renderGraph(
 				cells,
 				task.title,
-				task.recurrence,
 				streak,
 				this.plugin.settings.showStreakCount
 			);

--- a/src/main.ts
+++ b/src/main.ts
@@ -194,7 +194,6 @@ export default class OrgHabitsGraphPlugin extends Plugin {
 			const graphEl = GraphRenderer.renderGraph(
 				cells,
 				task.title,
-				task.recurrence,
 				streak,
 				this.settings.showStreakCount
 			);

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 /* Org Habits Graph Styles - Org-mode inspired */
 
-/* Each habit is a row with label on left, graph on right */
+/* Each habit is a row with label on left, SVG graph on right */
 .habit-graph-row {
 	display: flex;
 	align-items: center;
@@ -20,97 +20,52 @@
 	white-space: nowrap;
 }
 
-/* Wrapper to contain scrollable graph */
-.habit-graph-wrapper {
-	flex: 1;
-	min-width: 0;
-	position: relative;
-}
-
-/* Graph: Grid of colored blocks */
-.habit-graph {
-	display: flex;
-	gap: 1px;
-}
-
-/* Mobile: make graph scrollable horizontally */
 @media (max-width: 768px) {
 	.habit-label {
-		flex: 0 0 120px; /* Narrower labels on mobile */
-	}
-
-	.habit-graph-wrapper {
-		overflow-x: auto;
-		overflow-y: hidden;
-		-webkit-overflow-scrolling: touch;
-		touch-action: pan-x;
-
-		/* Hide scrollbar on mobile but keep scroll functionality */
-		scrollbar-width: none; /* Firefox */
-		-ms-overflow-style: none; /* IE/Edge */
-	}
-
-	.habit-graph-wrapper::-webkit-scrollbar {
-		display: none; /* Chrome/Safari */
-	}
-
-	.habit-graph {
-		min-width: max-content; /* Force graph to be full width on mobile */
+		flex: 0 0 120px;
 	}
 }
 
-.habit-day {
-	width: 14px;
-	height: 18px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	font-size: 10px;
-	font-weight: bold;
-	cursor: help;
-	border: 1px solid rgba(0, 0, 0, 0.1);
+/* SVG scales to fill remaining row width */
+.habit-graph-svg {
+	flex: 1;
+	min-width: 0;
+	display: block;
 }
 
-.habit-day:hover {
-	transform: scale(1.2);
-	z-index: 10;
-	box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
-}
-
-/* Org-mode color scheme:
-   Blue = not due yet
+/* Org-mode color scheme applied to SVG rects:
+   Blue = not due yet / rest
    Green = could be done / was done
    Yellow = going overdue (today, not done)
    Red = overdue / missed
+   Gray = skipped
 */
-
-.habit-day.blue {
-	background-color: #7aa6da; /* Blue - not to be done yet */
-	color: white;
+.habit-graph-svg rect {
+	stroke: rgba(0, 0, 0, 0.1);
+	stroke-width: 0.5;
+	fill: transparent;
 }
 
-.habit-day.green {
-	background-color: #5cb85c; /* Green - could be/was done */
-	color: white;
-}
+.habit-graph-svg .blue rect { fill: #7aa6da; }
+.habit-graph-svg .blue text { fill: white; }
 
-.habit-day.green-light {
-	background-color: #90ee90; /* Light green - good time to do (future) */
-	color: black;
-}
+.habit-graph-svg .green rect { fill: #5cb85c; }
+.habit-graph-svg .green text { fill: white; }
 
-.habit-day.yellow {
-	background-color: #f0ad4e; /* Yellow - going overdue */
-	color: black;
-}
+.habit-graph-svg .green-light rect { fill: #90ee90; }
+.habit-graph-svg .green-light text { fill: black; }
 
-.habit-day.red {
-	background-color: #d9534f; /* Red - overdue/missed */
-	color: white;
-}
+.habit-graph-svg .yellow rect { fill: #f0ad4e; }
+.habit-graph-svg .yellow text { fill: black; }
 
-.today-indicator {
-	font-weight: bold;
+.habit-graph-svg .red rect { fill: #d9534f; }
+.habit-graph-svg .red text { fill: white; }
+
+.habit-graph-svg .gray rect { fill: #aaaaaa; }
+.habit-graph-svg .gray text { fill: white; }
+
+.habit-graph-svg text {
+	font-family: var(--font-monospace);
 }
 
 /* Error and Empty States */
@@ -151,22 +106,13 @@
 }
 
 /* Dark mode adjustments */
-.theme-dark .habit-day.blue {
-	background-color: #5f89ac;
+.theme-dark .habit-graph-svg rect {
+	stroke: rgba(255, 255, 255, 0.1);
 }
 
-.theme-dark .habit-day.green {
-	background-color: #4a934a;
-}
-
-.theme-dark .habit-day.green-light {
-	background-color: #6db36d;
-}
-
-.theme-dark .habit-day.yellow {
-	background-color: #c8883e;
-}
-
-.theme-dark .habit-day.red {
-	background-color: #b43c39;
-}
+.theme-dark .habit-graph-svg .blue rect { fill: #5f89ac; }
+.theme-dark .habit-graph-svg .green rect { fill: #4a934a; }
+.theme-dark .habit-graph-svg .green-light rect { fill: #6db36d; }
+.theme-dark .habit-graph-svg .yellow rect { fill: #c8883e; }
+.theme-dark .habit-graph-svg .red rect { fill: #b43c39; }
+.theme-dark .habit-graph-svg .gray rect { fill: #888888; }


### PR DESCRIPTION
## Summary

- Replace HTML div-based graph rendering with percentage-based SVG — cells stretch to fill container width at any screen size
- Remove touch drag scroll handlers (no longer needed with fluid SVG scaling)
- Add missing gray color for skipped days
- Remove unused `recurrence` parameter from `renderGraph`

Closes #24

## Test plan

- [ ] Graph renders correctly in sidebar view on desktop
- [ ] Graph renders correctly in code block embed
- [ ] Graph scales to narrow widths without horizontal scrolling
- [ ] Color semantics preserved (green/blue/yellow/red/gray)
- [ ] Today marker (`!`), completion (`*`), and skipped (`~`) markers visible
- [ ] Dark mode colors work correctly
- [ ] Test on mobile layout width