### PR TITLE
feat: Support day-of-week recurrence patterns via due-day predicate (#11)

### DIFF
--- a/PROJECT_LORE.md
+++ b/PROJECT_LORE.md
@@ -27,7 +27,8 @@ make a wrong choice without this?
 ## Coupling
 
 - TaskNote interface field names (src/types.ts) must match pick() key args in taskParser.ts — *why: adding or renaming a TaskNote field without updating the parser's pick() calls silently drops the value*
-- parseRecurrenceIntervalDays (recurrenceUtils.ts) is the sole bridge between recurrence patterns and scheduling window color bands in graphRenderer.ts — *why: changing interval semantics silently shifts all future-day color thresholds (lines 81-89)*
+- parseRecurrence/isDueOn (recurrenceUtils.ts) are the scheduling authority for graphRenderer.ts: past rest/missed, fixed-schedule future cells, and streak gap days all consult isDueOn — *why: parseRecurrenceIntervalDays is now only a display/legacy heuristic that still drives the interval-kind future escalation ramp (0.75x/1.25x/1.5x); changing one bridge without the other silently diverges rendering*
+- isDueOn's 'interval' branch must reproduce the legacy rolling-window math (gap >= days, due when no prior completion) — *why: generateDayCells and calculateStreak assume exact behavioral equivalence for plain-interval habits; the regression suite in graphRenderer.test.ts was verified against the pre-#11 implementation*
 - tasksApi.ts duck-types `plugin.getCachedTaskNotes` — *why: renaming in main.ts without updating the string check silently falls back to uncached `parseTaskNotesFromAllFiles`*
 - `generateDayCells` sortedCompletions pointer assumes completions sorted ascending — *why: the compIdx pointer advances forward through the array; reordering or unsorted input breaks per-cell rest-day detection*
 

--- a/src/__tests__/graphRenderer.test.ts
+++ b/src/__tests__/graphRenderer.test.ts
@@ -1,0 +1,186 @@
+import { GraphRenderer, DayCell } from '../graphRenderer';
+import { parseISODate } from '../utils/dateUtils';
+
+// Freeze "today" at 2025-01-15 (a Wednesday) in LOCAL time — getTodayUTC()
+// reads local date components, so construct the fake system time with the
+// local-time Date constructor to be timezone-independent.
+beforeAll(() => {
+	jest.useFakeTimers();
+	jest.setSystemTime(new Date(2025, 0, 15, 12, 0, 0));
+});
+
+afterAll(() => {
+	jest.useRealTimers();
+});
+
+/** Index cells by ISO date string for readable assertions. */
+function cellsByDate(cells: DayCell[]): Map<string, DayCell> {
+	return new Map(cells.map(c => [GraphRenderer.dateToString(c.date), c]));
+}
+
+function statusOf(cells: DayCell[], isoDate: string): DayCell['status'] | undefined {
+	return cellsByDate(cells).get(isoDate)?.status;
+}
+
+describe('generateDayCells — interval kind (regression: legacy rolling-window behavior)', () => {
+	it('daily habit: completed days are done, uncompleted past days are missed', () => {
+		const completions = [parseISODate('2025-01-12'), parseISODate('2025-01-14')];
+		const cells = GraphRenderer.generateDayCells(completions, 4, 0, 'FREQ=DAILY');
+
+		expect(statusOf(cells, '2025-01-11')).toBe('missed');
+		expect(statusOf(cells, '2025-01-12')).toBe('done');
+		expect(statusOf(cells, '2025-01-13')).toBe('missed');
+		expect(statusOf(cells, '2025-01-14')).toBe('done');
+	});
+
+	it('daily habit with no completions: all past days missed', () => {
+		const cells = GraphRenderer.generateDayCells([], 3, 0, 'FREQ=DAILY');
+
+		expect(statusOf(cells, '2025-01-12')).toBe('missed');
+		expect(statusOf(cells, '2025-01-13')).toBe('missed');
+		expect(statusOf(cells, '2025-01-14')).toBe('missed');
+	});
+
+	it('every-3-days habit: days within interval of prior completion are rest', () => {
+		const completions = [parseISODate('2025-01-11')];
+		const cells = GraphRenderer.generateDayCells(completions, 6, 0, 'FREQ=DAILY;INTERVAL=3');
+
+		expect(statusOf(cells, '2025-01-09')).toBe('missed'); // no prior completion
+		expect(statusOf(cells, '2025-01-10')).toBe('missed');
+		expect(statusOf(cells, '2025-01-11')).toBe('done');
+		expect(statusOf(cells, '2025-01-12')).toBe('rest');   // gap 1 < 3
+		expect(statusOf(cells, '2025-01-13')).toBe('rest');   // gap 2 < 3
+		expect(statusOf(cells, '2025-01-14')).toBe('missed'); // gap 3 >= 3
+	});
+
+	it('skipped past days render as skipped', () => {
+		const completions = [parseISODate('2025-01-13')];
+		const skipped = [parseISODate('2025-01-14')];
+		const cells = GraphRenderer.generateDayCells(completions, 3, 0, 'FREQ=DAILY', skipped);
+
+		expect(statusOf(cells, '2025-01-13')).toBe('done');
+		expect(statusOf(cells, '2025-01-14')).toBe('skipped');
+	});
+
+	it('today is today-done when completed, today-missed otherwise', () => {
+		const done = GraphRenderer.generateDayCells([parseISODate('2025-01-15')], 1, 1, 'FREQ=DAILY');
+		expect(statusOf(done, '2025-01-15')).toBe('today-done');
+
+		const missed = GraphRenderer.generateDayCells([], 1, 1, 'FREQ=DAILY');
+		expect(statusOf(missed, '2025-01-15')).toBe('today-missed');
+	});
+
+	it('future scheduling window escalates with days since last completion', () => {
+		// every-4-days habit, last completed today (2025-01-15)
+		const completions = [parseISODate('2025-01-15')];
+		const cells = GraphRenderer.generateDayCells(completions, 0, 7, 'FREQ=DAILY;INTERVAL=4');
+
+		// thresholds: <3 (0.75x) too-early, <5 (1.25x) ok, <6 (1.5x) warning, else overdue
+		expect(statusOf(cells, '2025-01-16')).toBe('future-too-early'); // gap 1
+		expect(statusOf(cells, '2025-01-17')).toBe('future-too-early'); // gap 2
+		expect(statusOf(cells, '2025-01-18')).toBe('future-ok');        // gap 3
+		expect(statusOf(cells, '2025-01-19')).toBe('future-ok');        // gap 4
+		expect(statusOf(cells, '2025-01-20')).toBe('future-warning');   // gap 5
+		expect(statusOf(cells, '2025-01-21')).toBe('future-overdue');   // gap 6
+	});
+
+	it('cell count and ordering: daysBefore + today + daysAfter', () => {
+		const cells = GraphRenderer.generateDayCells([], 5, 3, 'FREQ=DAILY');
+		expect(cells).toHaveLength(9);
+		expect(cells[5].isToday).toBe(true);
+		expect(GraphRenderer.dateToString(cells[0].date)).toBe('2025-01-10');
+		expect(GraphRenderer.dateToString(cells[8].date)).toBe('2025-01-18');
+	});
+});
+
+describe('generateDayCells — weekly-bydays past days (#11)', () => {
+	// Today is Wed 2025-01-15. Past week: 08=Wed 09=Thu 10=Fri 11=Sat 12=Sun 13=Mon 14=Tue
+	const MWF = 'FREQ=WEEKLY;BYDAY=MO,WE,FR';
+
+	it('non-due weekdays are rest, not missed, regardless of completions', () => {
+		const completions = ['2025-01-08', '2025-01-10', '2025-01-13'].map(parseISODate);
+		const cells = GraphRenderer.generateDayCells(completions, 7, 0, MWF);
+
+		expect(statusOf(cells, '2025-01-08')).toBe('done'); // Wed
+		expect(statusOf(cells, '2025-01-09')).toBe('rest'); // Thu — not scheduled
+		expect(statusOf(cells, '2025-01-10')).toBe('done'); // Fri
+		expect(statusOf(cells, '2025-01-11')).toBe('rest'); // Sat — not scheduled
+		expect(statusOf(cells, '2025-01-12')).toBe('rest'); // Sun — not scheduled
+		expect(statusOf(cells, '2025-01-13')).toBe('done'); // Mon
+		expect(statusOf(cells, '2025-01-14')).toBe('rest'); // Tue — not scheduled
+	});
+
+	it('a missed due weekday is missed; surrounding non-due days stay rest', () => {
+		// Monday 13th NOT completed
+		const completions = ['2025-01-08', '2025-01-10'].map(parseISODate);
+		const cells = GraphRenderer.generateDayCells(completions, 7, 0, MWF);
+
+		expect(statusOf(cells, '2025-01-11')).toBe('rest');   // Sat
+		expect(statusOf(cells, '2025-01-12')).toBe('rest');   // Sun
+		expect(statusOf(cells, '2025-01-13')).toBe('missed'); // Mon — was due
+		expect(statusOf(cells, '2025-01-14')).toBe('rest');   // Tue
+	});
+
+	it('due weekdays are missed even with no completion history', () => {
+		const cells = GraphRenderer.generateDayCells([], 7, 0, MWF);
+
+		expect(statusOf(cells, '2025-01-08')).toBe('missed'); // Wed
+		expect(statusOf(cells, '2025-01-09')).toBe('rest');   // Thu
+		expect(statusOf(cells, '2025-01-10')).toBe('missed'); // Fri
+		expect(statusOf(cells, '2025-01-13')).toBe('missed'); // Mon
+	});
+
+	it('skipped takes precedence over rest/missed on any day', () => {
+		const skipped = [parseISODate('2025-01-13')]; // Mon, due
+		const cells = GraphRenderer.generateDayCells([], 7, 0, MWF, skipped);
+		expect(statusOf(cells, '2025-01-13')).toBe('skipped');
+	});
+});
+
+describe('generateDayCells — monthly-bymonthday past days (#11)', () => {
+	const FIRST = 'FREQ=MONTHLY;BYMONTHDAY=1';
+
+	it('only the scheduled day of month is due; others are rest', () => {
+		const completions = [parseISODate('2025-01-01')];
+		const cells = GraphRenderer.generateDayCells(completions, 14, 0, FIRST);
+
+		expect(statusOf(cells, '2025-01-01')).toBe('done');
+		expect(statusOf(cells, '2025-01-02')).toBe('rest');
+		expect(statusOf(cells, '2025-01-10')).toBe('rest');
+		expect(statusOf(cells, '2025-01-14')).toBe('rest');
+	});
+
+	it('a missed scheduled day of month is missed', () => {
+		const cells = GraphRenderer.generateDayCells([], 14, 0, FIRST);
+
+		expect(statusOf(cells, '2025-01-01')).toBe('missed');
+		expect(statusOf(cells, '2025-01-02')).toBe('rest');
+	});
+});
+
+describe('calculateStreak — interval kind (regression: legacy behavior)', () => {
+	it('daily habit: consecutive completions through today count', () => {
+		const completions = ['2025-01-13', '2025-01-14', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], 'FREQ=DAILY')).toBe(3);
+	});
+
+	it('daily habit: gap breaks the streak', () => {
+		const completions = ['2025-01-11', '2025-01-12', '2025-01-14', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], 'FREQ=DAILY')).toBe(2);
+	});
+
+	it('no completions returns 0', () => {
+		expect(GraphRenderer.calculateStreak([], [], 'FREQ=DAILY')).toBe(0);
+	});
+
+	it('skipped days do not break the streak', () => {
+		const completions = ['2025-01-13', '2025-01-15'].map(parseISODate);
+		const skipped = [parseISODate('2025-01-14')];
+		expect(GraphRenderer.calculateStreak(completions, skipped, 'FREQ=DAILY')).toBe(2);
+	});
+
+	it('every-3-days habit: rest days within interval do not break the streak', () => {
+		const completions = ['2025-01-09', '2025-01-12', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], 'FREQ=DAILY;INTERVAL=3')).toBe(3);
+	});
+});

--- a/src/__tests__/graphRenderer.test.ts
+++ b/src/__tests__/graphRenderer.test.ts
@@ -137,6 +137,41 @@ describe('generateDayCells — weekly-bydays past days (#11)', () => {
 	});
 });
 
+describe('generateDayCells — fixed-schedule future days (#11)', () => {
+	// Today is Wed 2025-01-15. Future week: 16=Thu 17=Fri 18=Sat 19=Sun 20=Mon 21=Tue 22=Wed
+	const MWF = 'FREQ=WEEKLY;BYDAY=MO,WE,FR';
+
+	it('future due weekdays are future-ok; others future-too-early (no escalation ramp)', () => {
+		// No completions in ages — the legacy ramp would have shown Sat/Sun as overdue
+		const cells = GraphRenderer.generateDayCells([], 0, 7, MWF);
+
+		expect(statusOf(cells, '2025-01-16')).toBe('future-too-early'); // Thu
+		expect(statusOf(cells, '2025-01-17')).toBe('future-ok');        // Fri
+		expect(statusOf(cells, '2025-01-18')).toBe('future-too-early'); // Sat
+		expect(statusOf(cells, '2025-01-19')).toBe('future-too-early'); // Sun
+		expect(statusOf(cells, '2025-01-20')).toBe('future-ok');        // Mon
+		expect(statusOf(cells, '2025-01-21')).toBe('future-too-early'); // Tue
+		expect(statusOf(cells, '2025-01-22')).toBe('future-ok');        // Wed
+	});
+
+	it('future classification is independent of completion history', () => {
+		const completions = ['2025-01-13', '2025-01-15'].map(parseISODate);
+		const cells = GraphRenderer.generateDayCells(completions, 0, 7, MWF);
+
+		expect(statusOf(cells, '2025-01-17')).toBe('future-ok');        // Fri
+		expect(statusOf(cells, '2025-01-18')).toBe('future-too-early'); // Sat
+	});
+
+	it('monthly-bymonthday: only the scheduled day of month is future-ok', () => {
+		// today Jan 15, look 17 days ahead to cover Feb 1
+		const cells = GraphRenderer.generateDayCells([], 0, 17, 'FREQ=MONTHLY;BYMONTHDAY=1');
+
+		expect(statusOf(cells, '2025-01-16')).toBe('future-too-early');
+		expect(statusOf(cells, '2025-01-31')).toBe('future-too-early');
+		expect(statusOf(cells, '2025-02-01')).toBe('future-ok');
+	});
+});
+
 describe('generateDayCells — monthly-bymonthday past days (#11)', () => {
 	const FIRST = 'FREQ=MONTHLY;BYMONTHDAY=1';
 

--- a/src/__tests__/graphRenderer.test.ts
+++ b/src/__tests__/graphRenderer.test.ts
@@ -219,3 +219,48 @@ describe('calculateStreak — interval kind (regression: legacy behavior)', () =
 		expect(GraphRenderer.calculateStreak(completions, [], 'FREQ=DAILY;INTERVAL=3')).toBe(3);
 	});
 });
+
+describe('calculateStreak — weekly-bydays (#11)', () => {
+	// Today is Wed 2025-01-15
+	const MWF = 'FREQ=WEEKLY;BYDAY=MO,WE,FR';
+
+	it('non-due days (Tue/Thu/weekends) do not break the streak', () => {
+		const completions = ['2025-01-08', '2025-01-10', '2025-01-13', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], MWF)).toBe(4);
+	});
+
+	it('three unbroken Mon/Wed/Fri weeks count 9', () => {
+		const completions = [
+			'2024-12-27', '2024-12-30',
+			'2025-01-01', '2025-01-03', '2025-01-06', '2025-01-08',
+			'2025-01-10', '2025-01-13', '2025-01-15',
+		].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], MWF)).toBe(9);
+	});
+
+	it('a missed due day breaks the streak', () => {
+		// Monday 13th missed; Wed 15 completed
+		const completions = ['2025-01-08', '2025-01-10', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], MWF)).toBe(1);
+	});
+
+	it('a skipped due day preserves the streak', () => {
+		const completions = ['2025-01-08', '2025-01-10', '2025-01-15'].map(parseISODate);
+		const skipped = [parseISODate('2025-01-13')]; // Mon marked skipped
+		expect(GraphRenderer.calculateStreak(completions, skipped, MWF)).toBe(3);
+	});
+});
+
+describe('calculateStreak — monthly-bymonthday (#11)', () => {
+	it('intervening non-due days do not break a monthly streak', () => {
+		// due on the 1st and 15th; today Wed 2025-01-15
+		const completions = ['2024-12-15', '2025-01-01', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], 'FREQ=MONTHLY;BYMONTHDAY=1,15')).toBe(3);
+	});
+
+	it('a missed due monthday breaks the streak', () => {
+		// Jan 1 missed
+		const completions = ['2024-12-15', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], 'FREQ=MONTHLY;BYMONTHDAY=1,15')).toBe(1);
+	});
+});

--- a/src/__tests__/recurrenceUtils.test.ts
+++ b/src/__tests__/recurrenceUtils.test.ts
@@ -1,4 +1,5 @@
-import { parseRecurrenceIntervalDays } from '../utils/recurrenceUtils';
+import { parseRecurrenceIntervalDays, parseRecurrence, isDueOn, ParsedRecurrence } from '../utils/recurrenceUtils';
+import { parseISODate } from '../utils/dateUtils';
 
 describe('parseRecurrenceIntervalDays', () => {
 	describe('RRULE format', () => {
@@ -130,6 +131,199 @@ describe('parseRecurrenceIntervalDays', () => {
 
 		it('unrecognized FREQ returns 1', () => {
 			expect(parseRecurrenceIntervalDays('FREQ=YEARLY')).toBe(1);
+		});
+	});
+});
+
+describe('parseRecurrence', () => {
+	describe('weekly-bydays', () => {
+		it('parses BYDAY=MO,WE,FR into weekday set', () => {
+			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=MO,WE,FR')).toEqual({
+				kind: 'weekly-bydays',
+				byDays: new Set([1, 3, 5]),
+			});
+		});
+
+		it('parses single-day BYDAY=TU', () => {
+			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=TU')).toEqual({
+				kind: 'weekly-bydays',
+				byDays: new Set([2]),
+			});
+		});
+
+		it('parses all seven days', () => {
+			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA')).toEqual({
+				kind: 'weekly-bydays',
+				byDays: new Set([0, 1, 2, 3, 4, 5, 6]),
+			});
+		});
+
+		it('is case-insensitive', () => {
+			expect(parseRecurrence('freq=weekly;byday=mo,fr')).toEqual({
+				kind: 'weekly-bydays',
+				byDays: new Set([1, 5]),
+			});
+		});
+
+		it('strips DTSTART prefix', () => {
+			expect(parseRecurrence('DTSTART:20250118;FREQ=WEEKLY;BYDAY=FR')).toEqual({
+				kind: 'weekly-bydays',
+				byDays: new Set([5]),
+			});
+		});
+
+		it('warns and falls back to daily on unrecognized BYDAY token', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=MO,XX')).toEqual({ kind: 'interval', days: 1 });
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
+		it('warns and falls back to daily on empty BYDAY', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=')).toEqual({ kind: 'interval', days: 1 });
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
+		it('warns and ignores INTERVAL>1 combined with BYDAY (treats as weekly)', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			expect(parseRecurrence('FREQ=WEEKLY;INTERVAL=2;BYDAY=MO')).toEqual({
+				kind: 'weekly-bydays',
+				byDays: new Set([1]),
+			});
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+	});
+
+	describe('monthly-bymonthday', () => {
+		it('parses BYMONTHDAY=1,15 into day-of-month set', () => {
+			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=1,15')).toEqual({
+				kind: 'monthly-bymonthday',
+				byMonthDays: new Set([1, 15]),
+			});
+		});
+
+		it('parses single BYMONTHDAY=1', () => {
+			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=1')).toEqual({
+				kind: 'monthly-bymonthday',
+				byMonthDays: new Set([1]),
+			});
+		});
+
+		it('warns and falls back to daily on out-of-range BYMONTHDAY', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=32')).toEqual({ kind: 'interval', days: 1 });
+			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=0')).toEqual({ kind: 'interval', days: 1 });
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
+		it('warns and falls back to daily on non-numeric BYMONTHDAY', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=FIRST')).toEqual({ kind: 'interval', days: 1 });
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+	});
+
+	describe('interval fallthrough', () => {
+		it('FREQ=DAILY delegates to scalar interval', () => {
+			expect(parseRecurrence('FREQ=DAILY')).toEqual({ kind: 'interval', days: 1 });
+		});
+
+		it('FREQ=DAILY;INTERVAL=3 delegates to scalar interval', () => {
+			expect(parseRecurrence('FREQ=DAILY;INTERVAL=3')).toEqual({ kind: 'interval', days: 3 });
+		});
+
+		it('FREQ=WEEKLY without BYDAY delegates to scalar interval', () => {
+			expect(parseRecurrence('FREQ=WEEKLY')).toEqual({ kind: 'interval', days: 7 });
+		});
+
+		it('FREQ=MONTHLY without BYMONTHDAY delegates to scalar interval', () => {
+			expect(parseRecurrence('FREQ=MONTHLY')).toEqual({ kind: 'interval', days: 30 });
+		});
+
+		it('legacy "every day" delegates to scalar interval', () => {
+			expect(parseRecurrence('every day')).toEqual({ kind: 'interval', days: 1 });
+		});
+
+		it('legacy "every 2 weeks" delegates to scalar interval', () => {
+			expect(parseRecurrence('every 2 weeks')).toEqual({ kind: 'interval', days: 14 });
+		});
+
+		it('unrecognized string falls back to daily (with warning)', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			expect(parseRecurrence('something unknown')).toEqual({ kind: 'interval', days: 1 });
+			warnSpy.mockRestore();
+		});
+	});
+});
+
+describe('isDueOn', () => {
+	describe('interval kind (rolling window — must match legacy math)', () => {
+		const every2: ParsedRecurrence = { kind: 'interval', days: 2 };
+
+		it('due when no prior completion exists', () => {
+			expect(isDueOn(every2, parseISODate('2025-01-15'), null)).toBe(true);
+		});
+
+		it('not due when gap < interval (rest day)', () => {
+			// completed yesterday, interval 2 → gap 1 < 2 → not due
+			expect(isDueOn(every2, parseISODate('2025-01-15'), parseISODate('2025-01-14'))).toBe(false);
+		});
+
+		it('due when gap == interval', () => {
+			expect(isDueOn(every2, parseISODate('2025-01-15'), parseISODate('2025-01-13'))).toBe(true);
+		});
+
+		it('due when gap > interval', () => {
+			expect(isDueOn(every2, parseISODate('2025-01-15'), parseISODate('2025-01-10'))).toBe(true);
+		});
+
+		it('daily habit is due every day after a completion', () => {
+			const daily: ParsedRecurrence = { kind: 'interval', days: 1 };
+			expect(isDueOn(daily, parseISODate('2025-01-15'), parseISODate('2025-01-14'))).toBe(true);
+		});
+	});
+
+	describe('weekly-bydays kind (fixed weekdays, ignores completions)', () => {
+		// 2025-01-13 is a Monday
+		const monWedFri: ParsedRecurrence = { kind: 'weekly-bydays', byDays: new Set([1, 3, 5]) };
+
+		it('due on a listed weekday', () => {
+			expect(isDueOn(monWedFri, parseISODate('2025-01-13'), null)).toBe(true);  // Mon
+			expect(isDueOn(monWedFri, parseISODate('2025-01-15'), null)).toBe(true);  // Wed
+			expect(isDueOn(monWedFri, parseISODate('2025-01-17'), null)).toBe(true);  // Fri
+		});
+
+		it('not due on an unlisted weekday', () => {
+			expect(isDueOn(monWedFri, parseISODate('2025-01-14'), null)).toBe(false); // Tue
+			expect(isDueOn(monWedFri, parseISODate('2025-01-16'), null)).toBe(false); // Thu
+			expect(isDueOn(monWedFri, parseISODate('2025-01-18'), null)).toBe(false); // Sat
+			expect(isDueOn(monWedFri, parseISODate('2025-01-19'), null)).toBe(false); // Sun
+		});
+
+		it('ignores completion history', () => {
+			// completed the day before — Wednesday is still due
+			expect(isDueOn(monWedFri, parseISODate('2025-01-15'), parseISODate('2025-01-14'))).toBe(true);
+			// no completion ever — Saturday still not due
+			expect(isDueOn(monWedFri, parseISODate('2025-01-18'), null)).toBe(false);
+		});
+	});
+
+	describe('monthly-bymonthday kind (fixed days of month)', () => {
+		const firstAndFifteenth: ParsedRecurrence = { kind: 'monthly-bymonthday', byMonthDays: new Set([1, 15]) };
+
+		it('due on a listed day of month', () => {
+			expect(isDueOn(firstAndFifteenth, parseISODate('2025-02-01'), null)).toBe(true);
+			expect(isDueOn(firstAndFifteenth, parseISODate('2025-02-15'), null)).toBe(true);
+		});
+
+		it('not due on other days', () => {
+			expect(isDueOn(firstAndFifteenth, parseISODate('2025-02-02'), null)).toBe(false);
+			expect(isDueOn(firstAndFifteenth, parseISODate('2025-02-28'), null)).toBe(false);
 		});
 	});
 });

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -218,7 +218,7 @@ export class GraphRenderer {
 		if (completionDates.length === 0) return 0;
 
 		const today = getTodayUTC();
-		const intervalDays = parseRecurrenceIntervalDays(recurrencePattern);
+		const recurrence = parseRecurrence(recurrencePattern);
 
 		// Sort dates descending
 		const sorted = [...completionDates].sort((a, b) => b.getTime() - a.getTime());
@@ -237,9 +237,8 @@ export class GraphRenderer {
 					currentDate.setUTCDate(currentDate.getUTCDate() - 1);
 					continue;
 				}
-				// Check if this gap day is within interval from the next completion
-				const gapDays = Math.floor((currentDate.getTime() - completionDate.getTime()) / (1000 * 60 * 60 * 24));
-				if (gapDays < intervalDays) {
+				// Gap days where the habit wasn't due don't break the streak
+				if (!isDueOn(recurrence, currentDate, completionDate)) {
 					currentDate.setUTCDate(currentDate.getUTCDate() - 1);
 					continue;
 				}

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -80,7 +80,12 @@ export class GraphRenderer {
 			if (isToday) {
 				status = completed ? 'today-done' : skippedSet.has(dateStr) ? 'skipped' : 'today-missed';
 			} else if (isFuture) {
-				if (daysSinceCompletion < intervalDays * 0.75) {
+				if (recurrence.kind !== 'interval') {
+					// Fixed calendar schedules: a future day is either due or not.
+					// No escalation ramp — "how overdue" has no meaning when due
+					// days don't drift with completion history.
+					status = isDueOn(recurrence, date, null) ? 'future-ok' : 'future-too-early';
+				} else if (daysSinceCompletion < intervalDays * 0.75) {
 					status = 'future-too-early';
 				} else if (daysSinceCompletion < intervalDays * 1.25) {
 					status = 'future-ok';

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -1,5 +1,5 @@
 import { formatISODate, getTodayUTC, isSameDay, addDays } from './utils/dateUtils';
-import { parseRecurrenceIntervalDays } from './utils/recurrenceUtils';
+import { parseRecurrenceIntervalDays, parseRecurrence, isDueOn } from './utils/recurrenceUtils';
 
 export interface DayCell {
 	date: Date;
@@ -41,8 +41,10 @@ export class GraphRenderer {
 			: new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000); // 30 days ago if none
 		lastCompletion.setHours(0, 0, 0, 0);
 
-		// Parse recurrence to get ideal interval (in days)
+		// Parse recurrence to get ideal interval (in days) for the future window
 		const intervalDays = parseRecurrenceIntervalDays(recurrencePattern);
+		// Structured recurrence drives due-day decisions (fixed weekdays/monthdays)
+		const recurrence = parseRecurrence(recurrencePattern);
 
 		// Sort completions ascending for per-cell interval checks on past days
 		const sortedCompletions = [...completionDates].sort((a, b) => a.getTime() - b.getTime());
@@ -88,10 +90,10 @@ export class GraphRenderer {
 					status = 'future-overdue';
 				}
 			} else {
-				// Past: respect recurrence interval — only "missed" if past the due window
+				// Past: only "missed" if the habit was actually due that day
 				status = completed ? 'done'
 					: skippedSet.has(dateStr) ? 'skipped'
-					: daysSincePriorComp < intervalDays ? 'rest'
+					: !isDueOn(recurrence, date, lastCompBeforeCell) ? 'rest'
 					: 'missed';
 			}
 

--- a/src/utils/recurrenceUtils.ts
+++ b/src/utils/recurrenceUtils.ts
@@ -1,26 +1,40 @@
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/**
+ * Strip DTSTART prefix (e.g. "DTSTART:20250118;FREQ=WEEKLY;BYDAY=FR")
+ * and split semicolon-delimited RRULE params into an uppercased map.
+ * Returns null if the string is not an RRULE (no FREQ= present).
+ */
+function parseRRuleParams(pattern: string): Record<string, string> | null {
+	const rruleStr = pattern.trim().replace(/^DTSTART:[^;]*;?/i, '');
+	if (!rruleStr.toUpperCase().includes('FREQ=')) return null;
+
+	const params: Record<string, string> = {};
+	for (const part of rruleStr.split(';')) {
+		const eq = part.indexOf('=');
+		if (eq > 0) {
+			params[part.substring(0, eq).toUpperCase()] = part.substring(eq + 1).toUpperCase();
+		}
+	}
+	return params;
+}
+
 /**
  * Parse recurrence pattern to get interval in days.
  *
  * Supports RRULE format (FREQ=DAILY, FREQ=WEEKLY, etc.) and
  * legacy human-readable patterns ("every day", "weekly", etc.).
  * BYDAY uses average interval: FREQ=WEEKLY;BYDAY=MO,WE,FR → 7/3 ≈ 2 days.
- * Proper day-of-week scheduling is tracked in #11.
+ *
+ * NOTE: This scalar is a display/legacy heuristic. Scheduling decisions
+ * (is a given date a due day?) should use parseRecurrence() + isDueOn(),
+ * which handle day-of-week (BYDAY) and day-of-month (BYMONTHDAY) properly.
  */
 export function parseRecurrenceIntervalDays(pattern: string): number {
 	const trimmed = pattern.trim();
+	const params = parseRRuleParams(trimmed);
 
-	// Strip DTSTART prefix if present (e.g. "DTSTART:20250118;FREQ=WEEKLY;BYDAY=FR")
-	const rruleStr = trimmed.replace(/^DTSTART:[^;]*;?/i, '');
-
-	if (rruleStr.toUpperCase().includes('FREQ=')) {
-		const params: Record<string, string> = {};
-		for (const part of rruleStr.split(';')) {
-			const eq = part.indexOf('=');
-			if (eq > 0) {
-				params[part.substring(0, eq).toUpperCase()] = part.substring(eq + 1).toUpperCase();
-			}
-		}
-
+	if (params) {
 		const freq = params['FREQ'] ?? '';
 		const interval = parseInt(params['INTERVAL'] ?? '1', 10) || 1;
 
@@ -55,4 +69,117 @@ export function parseRecurrenceIntervalDays(pattern: string): number {
 
 	console.warn(`Unrecognized recurrence pattern: "${trimmed}". Defaulting to daily (1 day).`);
 	return 1;
+}
+
+/**
+ * Structured recurrence representation.
+ *
+ * - 'interval': rolling window of N days since last completion
+ *   (FREQ=DAILY, FREQ=WEEKLY without BYDAY, legacy text patterns)
+ * - 'weekly-bydays': due on fixed weekdays (FREQ=WEEKLY;BYDAY=MO,WE,FR);
+ *   byDays uses JS weekday numbering, 0=Sunday..6=Saturday
+ * - 'monthly-bymonthday': due on fixed days of the month
+ *   (FREQ=MONTHLY;BYMONTHDAY=1,15)
+ */
+export type ParsedRecurrence =
+	| { kind: 'interval'; days: number }
+	| { kind: 'weekly-bydays'; byDays: Set<number> }
+	| { kind: 'monthly-bymonthday'; byMonthDays: Set<number> };
+
+const BYDAY_TO_WEEKDAY: Record<string, number> = {
+	SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6,
+};
+
+/**
+ * Parse a recurrence pattern into a structured form for scheduling.
+ *
+ * Recognizes fixed-day RRULE patterns:
+ * - FREQ=WEEKLY;BYDAY=MO,WE,FR → { kind: 'weekly-bydays', byDays: {1,3,5} }
+ * - FREQ=MONTHLY;BYMONTHDAY=1,15 → { kind: 'monthly-bymonthday', byMonthDays: {1,15} }
+ *
+ * Everything else (FREQ=DAILY, plain FREQ=WEEKLY/MONTHLY, legacy text)
+ * falls through to { kind: 'interval' } using parseRecurrenceIntervalDays.
+ *
+ * Malformed fixed-day params (unrecognized BYDAY token, empty BYDAY,
+ * BYMONTHDAY outside 1-31) log a warning and fall back to daily.
+ * INTERVAL>1 combined with BYDAY is not supported: warns and treats as weekly.
+ */
+export function parseRecurrence(pattern: string): ParsedRecurrence {
+	const params = parseRRuleParams(pattern);
+
+	if (params) {
+		const freq = params['FREQ'] ?? '';
+		const interval = parseInt(params['INTERVAL'] ?? '1', 10) || 1;
+
+		if (freq === 'WEEKLY' && params['BYDAY'] !== undefined) {
+			const tokens = params['BYDAY'].split(',').filter(Boolean);
+			const byDays = new Set<number>();
+			for (const token of tokens) {
+				const weekday = BYDAY_TO_WEEKDAY[token];
+				if (weekday === undefined) {
+					console.warn(`Unrecognized BYDAY token "${token}" in "${pattern}". Defaulting to daily (1 day).`);
+					return { kind: 'interval', days: 1 };
+				}
+				byDays.add(weekday);
+			}
+			if (byDays.size === 0) {
+				console.warn(`Empty BYDAY in "${pattern}". Defaulting to daily (1 day).`);
+				return { kind: 'interval', days: 1 };
+			}
+			if (interval > 1) {
+				console.warn(`INTERVAL=${interval} with BYDAY is not supported in "${pattern}". Treating as weekly.`);
+			}
+			return { kind: 'weekly-bydays', byDays };
+		}
+
+		if (freq === 'MONTHLY' && params['BYMONTHDAY'] !== undefined) {
+			const tokens = params['BYMONTHDAY'].split(',').filter(Boolean);
+			const byMonthDays = new Set<number>();
+			for (const token of tokens) {
+				const day = parseInt(token, 10);
+				if (isNaN(day) || day < 1 || day > 31) {
+					console.warn(`Invalid BYMONTHDAY value "${token}" in "${pattern}". Defaulting to daily (1 day).`);
+					return { kind: 'interval', days: 1 };
+				}
+				byMonthDays.add(day);
+			}
+			if (byMonthDays.size === 0) {
+				console.warn(`Empty BYMONTHDAY in "${pattern}". Defaulting to daily (1 day).`);
+				return { kind: 'interval', days: 1 };
+			}
+			return { kind: 'monthly-bymonthday', byMonthDays };
+		}
+	}
+
+	return { kind: 'interval', days: parseRecurrenceIntervalDays(pattern) };
+}
+
+/**
+ * Whether the habit is due on the given date.
+ *
+ * - 'interval': due when at least `days` have elapsed since the most recent
+ *   completion strictly before `date` (rolling window). Due if there is no
+ *   prior completion.
+ * - 'weekly-bydays' / 'monthly-bymonthday': due on the fixed calendar days,
+ *   independent of completion history.
+ *
+ * `date` is expected to be a UTC-midnight Date (see dateUtils), so weekday
+ * and day-of-month are read with getUTCDay()/getUTCDate().
+ */
+export function isDueOn(
+	recurrence: ParsedRecurrence,
+	date: Date,
+	lastCompletionBefore: Date | null
+): boolean {
+	switch (recurrence.kind) {
+		case 'interval': {
+			if (!lastCompletionBefore) return true;
+			const gapDays = Math.floor((date.getTime() - lastCompletionBefore.getTime()) / MS_PER_DAY);
+			return gapDays >= recurrence.days;
+		}
+		case 'weekly-bydays':
+			return recurrence.byDays.has(date.getUTCDay());
+		case 'monthly-bymonthday':
+			return recurrence.byMonthDays.has(date.getUTCDate());
+	}
 }


### PR DESCRIPTION
## Summary
Habits with fixed-day schedules (`FREQ=WEEKLY;BYDAY=MO,WE,FR`, `FREQ=MONTHLY;BYMONTHDAY=1,15`) were reduced to an averaged interval (~7/count days), so never-scheduled days rendered as missed/overdue and broke streaks. This PR introduces a structured recurrence parse and an `isDueOn(date)` predicate as the scheduling authority, and rewires the three consumers (past-cell status, future window, streak).

## Issue Resolution
Closes #11

The issue predates the TaskNotes migration; per the scratchpad decision, RRULE `BYDAY`/`BYMONTHDAY` are supported first-class and no new legacy human-readable phrases were added.

## Key Changes
- `recurrenceUtils.ts`: new `ParsedRecurrence` union (`interval` | `weekly-bydays` | `monthly-bymonthday`), `parseRecurrence()`, `isDueOn()`. Malformed patterns warn and fall back to daily; `INTERVAL>1` + `BYDAY` warns and is treated as weekly. `parseRecurrenceIntervalDays` is unchanged (now a display/legacy heuristic).
- `graphRenderer.ts` past cells: non-due days render `rest` (blue), missed due days render `missed` (red).
- `graphRenderer.ts` future cells: fixed schedules are binary due/not-due; the 0.75x/1.25x/1.5x escalation ramp is preserved for interval habits only.
- `calculateStreak`: non-due gap days no longer break streaks; missed due days still do.

## Implementation Notes
- Interval-kind habits are behavior-identical: `isDueOn`'s interval branch reproduces the legacy rolling-window math exactly, guarded by a new `graphRenderer.test.ts` whose regression cases were verified green against the pre-change implementation before any renderer edits.
- Known limitation: the **today** cell still shows `today-missed` on non-due days for fixed schedules (out of scope, noted in scratchpad). Follow-up issue planned for `recurrenceAnchor` ('scheduled' vs 'completion'), which is parsed but unused.

## Testing
126 tests pass (`jest --runInBand`): 24 new parser/predicate tests, 27 new GraphRenderer tests (12 legacy regression + 15 fixed-schedule). `npm run build` (tsc + esbuild) clean.