### PR TITLE
feat: Open TaskNote on habit label click (#29)

### DIFF
--- a/src/__tests__/noteOpener.test.ts
+++ b/src/__tests__/noteOpener.test.ts
@@ -1,0 +1,127 @@
+import { openTaskNote } from '../utils/noteOpener';
+import { Notice, TFile } from 'obsidian';
+import type { App, WorkspaceLeaf } from 'obsidian';
+
+jest.mock('obsidian', () => {
+	const actual = jest.requireActual('../../__mocks__/obsidian');
+	return { ...actual, Notice: jest.fn() };
+});
+
+interface FakeAppHandles {
+	app: App;
+	setActiveLeaf: jest.Mock;
+	openFile: jest.Mock;
+	leaves: WorkspaceLeaf[];
+}
+
+function makeFile(path: string): TFile {
+	return Object.assign(new TFile(), { path });
+}
+
+function makeApp(options: {
+	file?: TFile | null;
+	openPaths?: string[];
+	extraLeaves?: unknown[];
+}): FakeAppHandles {
+	const setActiveLeaf = jest.fn();
+	const openFile = jest.fn().mockResolvedValue(undefined);
+	const leaves = [
+		...(options.openPaths ?? []).map(path => ({ view: { file: { path } } })),
+		...(options.extraLeaves ?? [])
+	] as WorkspaceLeaf[];
+
+	const app = {
+		vault: {
+			getAbstractFileByPath: jest.fn().mockReturnValue(options.file ?? null)
+		},
+		workspace: {
+			getLeavesOfType: jest.fn().mockReturnValue(leaves),
+			setActiveLeaf,
+			getLeaf: jest.fn().mockReturnValue({ openFile })
+		}
+	} as unknown as App;
+
+	return { app, setActiveLeaf, openFile, leaves };
+}
+
+describe('openTaskNote', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('missing file guard', () => {
+		it('shows a Notice and does not open anything when the path does not resolve', async () => {
+			const { app, setActiveLeaf, openFile } = makeApp({ file: null });
+
+			await openTaskNote(app, 'habits/deleted.md');
+
+			expect(Notice).toHaveBeenCalledWith('TaskNote not found: habits/deleted.md');
+			expect(setActiveLeaf).not.toHaveBeenCalled();
+			expect(openFile).not.toHaveBeenCalled();
+		});
+
+		it('treats a non-TFile result (e.g. a folder) as missing', async () => {
+			const { app, openFile } = makeApp({});
+			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue({ path: 'habits' });
+
+			await openTaskNote(app, 'habits');
+
+			expect(Notice).toHaveBeenCalledWith('TaskNote not found: habits');
+			expect(openFile).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('reuse existing leaf', () => {
+		it('focuses the leaf that already has the note open instead of opening a new tab', async () => {
+			const file = makeFile('habits/workout.md');
+			const { app, setActiveLeaf, openFile, leaves } = makeApp({
+				file,
+				openPaths: ['journal/today.md', 'habits/workout.md']
+			});
+
+			await openTaskNote(app, 'habits/workout.md');
+
+			expect(setActiveLeaf).toHaveBeenCalledWith(leaves[1], { focus: true });
+			expect(openFile).not.toHaveBeenCalled();
+			expect(Notice).not.toHaveBeenCalled();
+		});
+
+		it('ignores leaves whose view has no file (e.g. empty tabs) without crashing', async () => {
+			const file = makeFile('habits/workout.md');
+			const { app, openFile } = makeApp({
+				file,
+				extraLeaves: [{ view: {} }, { view: { file: null } }, {}]
+			});
+
+			await openTaskNote(app, 'habits/workout.md');
+
+			expect(openFile).toHaveBeenCalledWith(file);
+		});
+	});
+
+	describe('open in new tab', () => {
+		it('opens the file in a new tab when it is not open anywhere', async () => {
+			const file = makeFile('habits/workout.md');
+			const { app, setActiveLeaf, openFile } = makeApp({
+				file,
+				openPaths: ['journal/today.md']
+			});
+
+			await openTaskNote(app, 'habits/workout.md');
+
+			expect(app.workspace.getLeaf).toHaveBeenCalledWith('tab');
+			expect(openFile).toHaveBeenCalledWith(file);
+			expect(setActiveLeaf).not.toHaveBeenCalled();
+			expect(Notice).not.toHaveBeenCalled();
+		});
+
+		it('opens a new tab when no markdown leaves exist at all', async () => {
+			const file = makeFile('habits/workout.md');
+			const { app, openFile } = makeApp({ file });
+
+			await openTaskNote(app, 'habits/workout.md');
+
+			expect(openFile).toHaveBeenCalledWith(file);
+		});
+	});
+});

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -120,7 +120,8 @@ export class GraphRenderer {
 		cells: DayCell[],
 		habitName: string,
 		streak: number,
-		showStreak: boolean
+		showStreak: boolean,
+		onLabelClick?: () => void
 	): HTMLElement {
 		const container = document.createElement('div');
 		container.className = 'habit-graph-row';
@@ -128,6 +129,12 @@ export class GraphRenderer {
 		const labelContainer = container.createDiv({ cls: 'habit-label' });
 		const cleanName = habitName.replace(/#habit/g, '').trim();
 		labelContainer.textContent = cleanName;
+
+		if (onLabelClick) {
+			// Plain listener is safe: the element is discarded on every
+			// re-render, never reused, so no registerDomEvent cleanup needed
+			labelContainer.addEventListener('click', onLabelClick);
+		}
 
 		if (showStreak && streak > 0) {
 			const streakEl = labelContainer.createSpan({ cls: 'habit-streak' });

--- a/src/habitGraphView.ts
+++ b/src/habitGraphView.ts
@@ -1,6 +1,7 @@
 import { ItemView, WorkspaceLeaf } from 'obsidian';
 import type OrgHabitsGraphPlugin from './main';
 import { GraphRenderer } from './graphRenderer';
+import { openTaskNote } from './utils/noteOpener';
 
 export const VIEW_TYPE_HABIT_GRAPH = 'habit-graph-view';
 
@@ -63,7 +64,8 @@ export class HabitGraphView extends ItemView {
 				cells,
 				task.title,
 				streak,
-				this.plugin.settings.showStreakCount
+				this.plugin.settings.showStreakCount,
+				() => openTaskNote(this.app, task.path)
 			);
 
 			container.appendChild(graphEl);

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { HabitGraphView, VIEW_TYPE_HABIT_GRAPH } from './habitGraphView';
 import { GraphRenderer } from './graphRenderer';
 import { TaskCacheManager } from './cache/TaskCacheManager';
 import { VaultEventHandler } from './events/VaultEventHandler';
+import { openTaskNote } from './utils/noteOpener';
 
 export default class OrgHabitsGraphPlugin extends Plugin {
 	settings: HabitGraphSettings;
@@ -195,7 +196,8 @@ export default class OrgHabitsGraphPlugin extends Plugin {
 				cells,
 				task.title,
 				streak,
-				this.settings.showStreakCount
+				this.settings.showStreakCount,
+				() => openTaskNote(this.app, task.path)
 			);
 
 			el.appendChild(graphEl);

--- a/src/utils/noteOpener.ts
+++ b/src/utils/noteOpener.ts
@@ -1,0 +1,32 @@
+import { Notice, TFile } from 'obsidian';
+import type { App, WorkspaceLeaf } from 'obsidian';
+
+/**
+ * Open a TaskNote in the workspace.
+ *
+ * Behavior contract:
+ * 1. If `path` does not resolve to an existing file, show a Notice and do
+ *    nothing — never let Obsidian silently create an empty note at a stale path.
+ * 2. If the note is already open in a markdown leaf, focus that leaf instead
+ *    of opening a duplicate tab.
+ * 3. Otherwise, open the note in a new tab.
+ */
+export async function openTaskNote(app: App, path: string): Promise<void> {
+	const file = app.vault.getAbstractFileByPath(path);
+	if (!(file instanceof TFile)) {
+		new Notice(`TaskNote not found: ${path}`);
+		return;
+	}
+
+	for (const leaf of app.workspace.getLeavesOfType('markdown')) {
+		// Shape check instead of instanceof MarkdownView: keeps the helper
+		// testable with plain object fakes in the node jest environment
+		const viewFile = (leaf as WorkspaceLeaf & { view?: { file?: TFile | null } }).view?.file;
+		if (viewFile?.path === path) {
+			app.workspace.setActiveLeaf(leaf, { focus: true });
+			return;
+		}
+	}
+
+	await app.workspace.getLeaf('tab').openFile(file);
+}

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,12 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	/* Label is clickable: opens the backing TaskNote */
+	cursor: pointer;
+}
+
+.habit-label:hover {
+	text-decoration: underline;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
Habit labels in the graph are now clickable navigation: clicking a label opens the backing TaskNote. Applies to both the sidebar view and `habit-graph` code blocks, with a pointer-cursor/underline hover affordance so the label reads as clickable.

## Issue Resolution
Closes #29

- Label click in the sidebar view opens the TaskNote ✓
- Label click in code-block-rendered graphs does the same ✓
- Visual hover affordance on the label ✓

## Key Changes
- **`src/utils/noteOpener.ts` (new):** `openTaskNote(app, path)` — guards missing files (Notice + no-op instead of Obsidian's silent note creation), focuses an existing markdown leaf if the note is already open, otherwise opens a new tab
- **`src/graphRenderer.ts`:** optional `onLabelClick` callback param on `renderGraph`; the renderer stays free of Obsidian App imports
- **`src/habitGraphView.ts` / `src/main.ts`:** both call sites pass `() => openTaskNote(this.app, task.path)`
- **`styles.css`:** `cursor: pointer` + underline on hover for `.habit-label`

## Implementation Notes
- **Deviation from issue title:** per review decision, an already-open note is *focused* rather than duplicated in a new tab; a new tab is only opened when the note isn't open anywhere
- Plain `addEventListener` (no `registerDomEvent`) is intentional — label elements are discarded on every re-render, never reused
- The 🔥 streak span is inside the label, so clicks on it bubble through (whole label is one clickable unit, by decision)

## Testing
- 6 new unit tests for `openTaskNote` (missing-file guard, folder-path guard, leaf reuse, file-less leaves, new-tab fallback) using object fakes in the existing node jest environment
- Full suite: 132 tests pass (`jest --runInBand`); `npm run build` clean
- DOM click-wiring itself ships untested (no jsdom infra — consistent with the rest of `renderGraph`)