### PR TITLE
feat: Support recurrence_anchor in scheduling semantics (#27)

### DIFF
--- a/PROJECT_LORE.md
+++ b/PROJECT_LORE.md
@@ -11,6 +11,7 @@ make a wrong choice without this?
 - `getTodayUTC()` must use local date components (`getFullYear/Month/Date`), not UTC (`getUTCFullYear/Month/Date`) — *why: at negative UTC offsets (e.g. PDT), UTC date can be tomorrow; "today" must match the user's wall clock*
 - graphRenderer must guard `colorClass` before `setAttribute('class', ...)` on SVG `<g>` elements — *why: empty class attributes are harmless but the guard (`if (colorClass)`) prevents meaningless DOM writes; pattern replaced addClass() in the SVG rewrite*
 - SVG elements in graphRenderer must use `document.createElementNS('http://www.w3.org/2000/svg', ...)`, not `document.createElement()` — *why: createElement produces HTML elements that render invisible inside SVG context*
+- isDueOn's scheduled-anchor interval branch must SILENTLY fall back to rolling-window completion math when scheduledDate is null — *why: 'scheduled' is the frontmatter default and most habits set no scheduled date; this fallback is what keeps pre-#27 default behavior unchanged. Do not add a console.warn here (it's the common case) and do not "fix" it to throw*
 
 ## Gotchas
 
@@ -27,8 +28,10 @@ make a wrong choice without this?
 ## Coupling
 
 - TaskNote interface field names (src/types.ts) must match pick() key args in taskParser.ts — *why: adding or renaming a TaskNote field without updating the parser's pick() calls silently drops the value*
-- parseRecurrence/isDueOn (recurrenceUtils.ts) are the scheduling authority for graphRenderer.ts: past rest/missed, fixed-schedule future cells, and streak gap days all consult isDueOn — *why: parseRecurrenceIntervalDays is now only a display/legacy heuristic that still drives the interval-kind future escalation ramp (0.75x/1.25x/1.5x); changing one bridge without the other silently diverges rendering*
-- isDueOn's 'interval' branch must reproduce the legacy rolling-window math (gap >= days, due when no prior completion) — *why: generateDayCells and calculateStreak assume exact behavioral equivalence for plain-interval habits; the regression suite in graphRenderer.test.ts was verified against the pre-#11 implementation*
+- parseRecurrence/isDueOn (recurrenceUtils.ts) are the scheduling authority for graphRenderer.ts: past rest/missed, fixed-schedule future cells, and streak gap days all consult isDueOn — *why: parseRecurrenceIntervalDays is now only a display/legacy heuristic that still drives the interval-kind future escalation ramp (0.75x/1.25x/1.5x, completion-anchor/fallback habits only since #27); changing one bridge without the other silently diverges rendering*
+- isDueOn's 'interval' branch must reproduce the legacy rolling-window math (gap >= days, due when no prior completion) on the completion-anchor/null-scheduledDate paths — *why: generateDayCells and calculateStreak assume exact behavioral equivalence for plain-interval habits; the regression suite in graphRenderer.test.ts was verified against the pre-#11 implementation*
+- main.ts renderHabitGraphCodeBlock and habitGraphView.ts refresh duplicate the render wiring (parseISODateOrNull(task.scheduled) + recurrenceAnchor/scheduledDate trailing args to generateDayCells AND calculateStreak) — *why: changing the arg list at one call site without the other silently renders sidebar and code blocks differently*
+- generateDayCells/calculateStreak new params must be appended trailing-with-defaults, never inserted — *why: all call sites (including the large test suites) pass positionally; inserting shifts meanings without a type error for same-typed params*
 - tasksApi.ts duck-types `plugin.getCachedTaskNotes` — *why: renaming in main.ts without updating the string check silently falls back to uncached `parseTaskNotesFromAllFiles`*
 - `generateDayCells` sortedCompletions pointer assumes completions sorted ascending — *why: the compIdx pointer advances forward through the array; reordering or unsorted input breaks per-cell rest-day detection*
 

--- a/src/__tests__/dateUtils.test.ts
+++ b/src/__tests__/dateUtils.test.ts
@@ -1,0 +1,26 @@
+import { parseISODateOrNull, formatISODate } from '../utils/dateUtils';
+
+describe('parseISODateOrNull', () => {
+	it('parses a bare YYYY-MM-DD date', () => {
+		const date = parseISODateOrNull('2025-01-15');
+		expect(date).not.toBeNull();
+		expect(formatISODate(date as Date)).toBe('2025-01-15');
+	});
+
+	it('accepts datetime strings, discarding the time portion', () => {
+		const date = parseISODateOrNull('2025-01-15T09:00');
+		expect(date).not.toBeNull();
+		expect(formatISODate(date as Date)).toBe('2025-01-15');
+	});
+
+	it('returns null for undefined and empty string', () => {
+		expect(parseISODateOrNull(undefined)).toBeNull();
+		expect(parseISODateOrNull('')).toBeNull();
+	});
+
+	it('returns null for values with no leading ISO date', () => {
+		expect(parseISODateOrNull('next tuesday')).toBeNull();
+		expect(parseISODateOrNull('15-01-2025')).toBeNull();
+		expect(parseISODateOrNull('someday')).toBeNull();
+	});
+});

--- a/src/__tests__/graphRenderer.test.ts
+++ b/src/__tests__/graphRenderer.test.ts
@@ -349,6 +349,37 @@ describe('calculateStreak — weekly-bydays (#11)', () => {
 	});
 });
 
+describe('calculateStreak — scheduled-anchor interval (#27)', () => {
+	// Today is Wed 2025-01-15; every 3 days anchored to 2025-01-09.
+	// Due days: 09, 12, 15.
+	const EVERY3 = 'FREQ=DAILY;INTERVAL=3';
+	const scheduled = parseISODate('2025-01-09');
+
+	it('off-cadence gap days do not break the streak', () => {
+		const completions = ['2025-01-09', '2025-01-12', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], EVERY3, 'scheduled', scheduled)).toBe(3);
+	});
+
+	it('a missed on-cadence day breaks the streak', () => {
+		// 2025-01-12 was due but not completed
+		const completions = ['2025-01-09', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], EVERY3, 'scheduled', scheduled)).toBe(1);
+	});
+
+	it('off-cadence completions still count while no due day is missed', () => {
+		// Completed on due days 12 and 15, plus an off-cadence 13th — all three
+		// count, matching legacy interval semantics (completions accumulate as
+		// long as no intervening due day was missed)
+		const completions = ['2025-01-12', '2025-01-13', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], EVERY3, 'scheduled', scheduled)).toBe(3);
+	});
+
+	it('without a scheduled date, falls back to legacy rolling-window streak (regression)', () => {
+		const completions = ['2025-01-09', '2025-01-12', '2025-01-15'].map(parseISODate);
+		expect(GraphRenderer.calculateStreak(completions, [], EVERY3, 'scheduled', null)).toBe(3);
+	});
+});
+
 describe('calculateStreak — monthly-bymonthday (#11)', () => {
 	it('intervening non-due days do not break a monthly streak', () => {
 		// due on the 1st and 15th; today Wed 2025-01-15

--- a/src/__tests__/graphRenderer.test.ts
+++ b/src/__tests__/graphRenderer.test.ts
@@ -172,6 +172,53 @@ describe('generateDayCells — fixed-schedule future days (#11)', () => {
 	});
 });
 
+describe('generateDayCells — scheduled-anchor interval future days (#27)', () => {
+	// Today is Wed 2025-01-15; every 3 days anchored to 2025-01-09.
+	// Future due days: 18, 21, 24, ...
+	const EVERY3 = 'FREQ=DAILY;INTERVAL=3';
+	const scheduled = parseISODate('2025-01-09');
+
+	it('future cells are binary due/not-due, no escalation ramp', () => {
+		// No completions in ages — the ramp would have painted everything overdue
+		const cells = GraphRenderer.generateDayCells([], 0, 7, EVERY3, [], 'scheduled', scheduled);
+
+		expect(statusOf(cells, '2025-01-16')).toBe('future-too-early');
+		expect(statusOf(cells, '2025-01-17')).toBe('future-too-early');
+		expect(statusOf(cells, '2025-01-18')).toBe('future-ok');
+		expect(statusOf(cells, '2025-01-19')).toBe('future-too-early');
+		expect(statusOf(cells, '2025-01-20')).toBe('future-too-early');
+		expect(statusOf(cells, '2025-01-21')).toBe('future-ok');
+		expect(statusOf(cells, '2025-01-22')).toBe('future-too-early');
+	});
+
+	it('future classification is independent of completion history', () => {
+		const completions = [parseISODate('2025-01-15')];
+		const cells = GraphRenderer.generateDayCells(completions, 0, 7, EVERY3, [], 'scheduled', scheduled);
+
+		expect(statusOf(cells, '2025-01-18')).toBe('future-ok');
+		expect(statusOf(cells, '2025-01-19')).toBe('future-too-early');
+	});
+
+	it('without a scheduled date, the escalation ramp still applies (regression)', () => {
+		// Identical to the legacy every-4-days ramp fixture
+		const completions = [parseISODate('2025-01-15')];
+		const cells = GraphRenderer.generateDayCells(completions, 0, 7, 'FREQ=DAILY;INTERVAL=4', [], 'scheduled', null);
+
+		expect(statusOf(cells, '2025-01-16')).toBe('future-too-early');
+		expect(statusOf(cells, '2025-01-18')).toBe('future-ok');
+		expect(statusOf(cells, '2025-01-20')).toBe('future-warning');
+		expect(statusOf(cells, '2025-01-21')).toBe('future-overdue');
+	});
+
+	it('completion anchor keeps the escalation ramp even with a scheduled date', () => {
+		const completions = [parseISODate('2025-01-15')];
+		const cells = GraphRenderer.generateDayCells(completions, 0, 7, 'FREQ=DAILY;INTERVAL=4', [], 'completion', scheduled);
+
+		expect(statusOf(cells, '2025-01-20')).toBe('future-warning');
+		expect(statusOf(cells, '2025-01-21')).toBe('future-overdue');
+	});
+});
+
 describe('generateDayCells — scheduled-anchor interval past days (#27)', () => {
 	// Today is Wed 2025-01-15; every 3 days anchored to scheduled date 2025-01-09.
 	// Due days: 09, 12, 15, 18, ...

--- a/src/__tests__/graphRenderer.test.ts
+++ b/src/__tests__/graphRenderer.test.ts
@@ -172,6 +172,57 @@ describe('generateDayCells — fixed-schedule future days (#11)', () => {
 	});
 });
 
+describe('generateDayCells — scheduled-anchor interval past days (#27)', () => {
+	// Today is Wed 2025-01-15; every 3 days anchored to scheduled date 2025-01-09.
+	// Due days: 09, 12, 15, 18, ...
+	const EVERY3 = 'FREQ=DAILY;INTERVAL=3';
+	const scheduled = parseISODate('2025-01-09');
+
+	it('due days follow the scheduled cadence, ignoring completion gaps', () => {
+		// Completed off-cadence on the 10th — under completion anchor the 12th
+		// would be rest (gap 2 < 3); under scheduled anchor it is due → missed.
+		const completions = [parseISODate('2025-01-10')];
+		const cells = GraphRenderer.generateDayCells(completions, 7, 0, EVERY3, [], 'scheduled', scheduled);
+
+		expect(statusOf(cells, '2025-01-09')).toBe('missed'); // due, not completed
+		expect(statusOf(cells, '2025-01-10')).toBe('done');
+		expect(statusOf(cells, '2025-01-11')).toBe('rest');   // off-cadence
+		expect(statusOf(cells, '2025-01-12')).toBe('missed'); // due despite gap 2 from the 10th
+		expect(statusOf(cells, '2025-01-13')).toBe('rest');
+		expect(statusOf(cells, '2025-01-14')).toBe('rest');
+	});
+
+	it('days before the scheduled date are rest, never missed', () => {
+		const cells = GraphRenderer.generateDayCells([], 10, 0, EVERY3, [], 'scheduled', scheduled);
+
+		expect(statusOf(cells, '2025-01-05')).toBe('rest');
+		expect(statusOf(cells, '2025-01-06')).toBe('rest'); // on-cadence backwards, still rest
+		expect(statusOf(cells, '2025-01-08')).toBe('rest');
+		expect(statusOf(cells, '2025-01-09')).toBe('missed'); // first due day
+	});
+
+	it('without a scheduled date, scheduled anchor falls back to rolling window (regression)', () => {
+		// Identical to the legacy every-3-days fixture — must classify identically
+		const completions = [parseISODate('2025-01-11')];
+		const cells = GraphRenderer.generateDayCells(completions, 6, 0, EVERY3, [], 'scheduled', null);
+
+		expect(statusOf(cells, '2025-01-09')).toBe('missed');
+		expect(statusOf(cells, '2025-01-10')).toBe('missed');
+		expect(statusOf(cells, '2025-01-11')).toBe('done');
+		expect(statusOf(cells, '2025-01-12')).toBe('rest');
+		expect(statusOf(cells, '2025-01-13')).toBe('rest');
+		expect(statusOf(cells, '2025-01-14')).toBe('missed');
+	});
+
+	it('completion anchor keeps rolling-window classification even with a scheduled date', () => {
+		const completions = [parseISODate('2025-01-11')];
+		const cells = GraphRenderer.generateDayCells(completions, 6, 0, EVERY3, [], 'completion', scheduled);
+
+		expect(statusOf(cells, '2025-01-12')).toBe('rest');   // gap 1 < 3, cadence irrelevant
+		expect(statusOf(cells, '2025-01-14')).toBe('missed'); // gap 3 >= 3
+	});
+});
+
 describe('generateDayCells — monthly-bymonthday past days (#11)', () => {
 	const FIRST = 'FREQ=MONTHLY;BYMONTHDAY=1';
 

--- a/src/__tests__/recurrenceUtils.test.ts
+++ b/src/__tests__/recurrenceUtils.test.ts
@@ -174,14 +174,14 @@ describe('parseRecurrence', () => {
 
 		it('warns and falls back to daily on unrecognized BYDAY token', () => {
 			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=MO,XX')).toEqual({ kind: 'interval', days: 1 });
+			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=MO,XX')).toEqual({ kind: 'interval', days: 1, anchor: 'scheduled' });
 			expect(warnSpy).toHaveBeenCalled();
 			warnSpy.mockRestore();
 		});
 
 		it('warns and falls back to daily on empty BYDAY', () => {
 			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=')).toEqual({ kind: 'interval', days: 1 });
+			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=')).toEqual({ kind: 'interval', days: 1, anchor: 'scheduled' });
 			expect(warnSpy).toHaveBeenCalled();
 			warnSpy.mockRestore();
 		});
@@ -214,15 +214,15 @@ describe('parseRecurrence', () => {
 
 		it('warns and falls back to daily on out-of-range BYMONTHDAY', () => {
 			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=32')).toEqual({ kind: 'interval', days: 1 });
-			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=0')).toEqual({ kind: 'interval', days: 1 });
+			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=32')).toEqual({ kind: 'interval', days: 1, anchor: 'scheduled' });
+			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=0')).toEqual({ kind: 'interval', days: 1, anchor: 'scheduled' });
 			expect(warnSpy).toHaveBeenCalled();
 			warnSpy.mockRestore();
 		});
 
 		it('warns and falls back to daily on non-numeric BYMONTHDAY', () => {
 			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=FIRST')).toEqual({ kind: 'interval', days: 1 });
+			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=FIRST')).toEqual({ kind: 'interval', days: 1, anchor: 'scheduled' });
 			expect(warnSpy).toHaveBeenCalled();
 			warnSpy.mockRestore();
 		});
@@ -230,32 +230,85 @@ describe('parseRecurrence', () => {
 
 	describe('interval fallthrough', () => {
 		it('FREQ=DAILY delegates to scalar interval', () => {
-			expect(parseRecurrence('FREQ=DAILY')).toEqual({ kind: 'interval', days: 1 });
+			expect(parseRecurrence('FREQ=DAILY')).toEqual({ kind: 'interval', days: 1, anchor: 'scheduled' });
 		});
 
 		it('FREQ=DAILY;INTERVAL=3 delegates to scalar interval', () => {
-			expect(parseRecurrence('FREQ=DAILY;INTERVAL=3')).toEqual({ kind: 'interval', days: 3 });
+			expect(parseRecurrence('FREQ=DAILY;INTERVAL=3')).toEqual({ kind: 'interval', days: 3, anchor: 'scheduled' });
 		});
 
 		it('FREQ=WEEKLY without BYDAY delegates to scalar interval', () => {
-			expect(parseRecurrence('FREQ=WEEKLY')).toEqual({ kind: 'interval', days: 7 });
+			expect(parseRecurrence('FREQ=WEEKLY')).toEqual({ kind: 'interval', days: 7, anchor: 'scheduled' });
 		});
 
 		it('FREQ=MONTHLY without BYMONTHDAY delegates to scalar interval', () => {
-			expect(parseRecurrence('FREQ=MONTHLY')).toEqual({ kind: 'interval', days: 30 });
+			expect(parseRecurrence('FREQ=MONTHLY')).toEqual({ kind: 'interval', days: 30, anchor: 'scheduled' });
 		});
 
 		it('legacy "every day" delegates to scalar interval', () => {
-			expect(parseRecurrence('every day')).toEqual({ kind: 'interval', days: 1 });
+			expect(parseRecurrence('every day')).toEqual({ kind: 'interval', days: 1, anchor: 'scheduled' });
 		});
 
 		it('legacy "every 2 weeks" delegates to scalar interval', () => {
-			expect(parseRecurrence('every 2 weeks')).toEqual({ kind: 'interval', days: 14 });
+			expect(parseRecurrence('every 2 weeks')).toEqual({ kind: 'interval', days: 14, anchor: 'scheduled' });
 		});
 
 		it('unrecognized string falls back to daily (with warning)', () => {
 			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-			expect(parseRecurrence('something unknown')).toEqual({ kind: 'interval', days: 1 });
+			expect(parseRecurrence('something unknown')).toEqual({ kind: 'interval', days: 1, anchor: 'scheduled' });
+			warnSpy.mockRestore();
+		});
+	});
+
+	describe('recurrence anchor threading', () => {
+		it('defaults to scheduled anchor when no anchor argument is given', () => {
+			expect(parseRecurrence('FREQ=DAILY;INTERVAL=3')).toEqual({
+				kind: 'interval', days: 3, anchor: 'scheduled',
+			});
+		});
+
+		it('carries completion anchor onto interval recurrences', () => {
+			expect(parseRecurrence('FREQ=DAILY;INTERVAL=3', 'completion')).toEqual({
+				kind: 'interval', days: 3, anchor: 'completion',
+			});
+			expect(parseRecurrence('every 2 days', 'completion')).toEqual({
+				kind: 'interval', days: 2, anchor: 'completion',
+			});
+		});
+
+		it('carries the anchor onto malformed-pattern daily fallbacks', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=XX', 'completion')).toEqual({
+				kind: 'interval', days: 1, anchor: 'completion',
+			});
+			warnSpy.mockRestore();
+		});
+
+		it('completion anchor on BYDAY is a warned no-op (stays calendar-fixed)', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			expect(parseRecurrence('FREQ=WEEKLY;BYDAY=MO,WE,FR', 'completion')).toEqual({
+				kind: 'weekly-bydays',
+				byDays: new Set([1, 3, 5]),
+			});
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('recurrence_anchor: completion has no effect'));
+			warnSpy.mockRestore();
+		});
+
+		it('completion anchor on BYMONTHDAY is a warned no-op (stays calendar-fixed)', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			expect(parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=1,15', 'completion')).toEqual({
+				kind: 'monthly-bymonthday',
+				byMonthDays: new Set([1, 15]),
+			});
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('recurrence_anchor: completion has no effect'));
+			warnSpy.mockRestore();
+		});
+
+		it('scheduled anchor on fixed-day schedules does not warn', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			parseRecurrence('FREQ=WEEKLY;BYDAY=MO,WE,FR', 'scheduled');
+			parseRecurrence('FREQ=MONTHLY;BYMONTHDAY=1', 'scheduled');
+			expect(warnSpy).not.toHaveBeenCalled();
 			warnSpy.mockRestore();
 		});
 	});
@@ -263,7 +316,7 @@ describe('parseRecurrence', () => {
 
 describe('isDueOn', () => {
 	describe('interval kind (rolling window — must match legacy math)', () => {
-		const every2: ParsedRecurrence = { kind: 'interval', days: 2 };
+		const every2: ParsedRecurrence = { kind: 'interval', days: 2, anchor: 'scheduled' };
 
 		it('due when no prior completion exists', () => {
 			expect(isDueOn(every2, parseISODate('2025-01-15'), null)).toBe(true);
@@ -283,8 +336,69 @@ describe('isDueOn', () => {
 		});
 
 		it('daily habit is due every day after a completion', () => {
-			const daily: ParsedRecurrence = { kind: 'interval', days: 1 };
+			const daily: ParsedRecurrence = { kind: 'interval', days: 1, anchor: 'scheduled' };
 			expect(isDueOn(daily, parseISODate('2025-01-15'), parseISODate('2025-01-14'))).toBe(true);
+		});
+	});
+
+	describe('interval kind, scheduled anchor with a scheduled date (fixed cadence)', () => {
+		const every3Scheduled: ParsedRecurrence = { kind: 'interval', days: 3, anchor: 'scheduled' };
+		const scheduled = parseISODate('2025-01-10');
+
+		it('due on the scheduled date itself', () => {
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-10'), null, scheduled)).toBe(true);
+		});
+
+		it('due on exact cadence multiples from the scheduled date', () => {
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-13'), null, scheduled)).toBe(true);
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-16'), null, scheduled)).toBe(true);
+			expect(isDueOn(every3Scheduled, parseISODate('2025-02-09'), null, scheduled)).toBe(true); // +30 days
+		});
+
+		it('not due on off-cadence days', () => {
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-11'), null, scheduled)).toBe(false);
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-12'), null, scheduled)).toBe(false);
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-14'), null, scheduled)).toBe(false);
+		});
+
+		it('never due before the scheduled date', () => {
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-09'), null, scheduled)).toBe(false);
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-07'), null, scheduled)).toBe(false); // on-cadence going backwards
+		});
+
+		it('ignores completion history entirely', () => {
+			// completed yesterday — on-cadence day is still due
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-13'), parseISODate('2025-01-12'), scheduled)).toBe(true);
+			// long gap since completion — off-cadence day is still not due
+			expect(isDueOn(every3Scheduled, parseISODate('2025-01-14'), parseISODate('2025-01-01'), scheduled)).toBe(false);
+		});
+	});
+
+	describe('interval kind, anchor/scheduledDate fallback contract', () => {
+		const every2Scheduled: ParsedRecurrence = { kind: 'interval', days: 2, anchor: 'scheduled' };
+		const every2Completion: ParsedRecurrence = { kind: 'interval', days: 2, anchor: 'completion' };
+
+		it('scheduled anchor without a scheduled date falls back to the rolling window (silent, load-bearing)', () => {
+			// Pinned against the legacy pre-anchor implementation
+			expect(isDueOn(every2Scheduled, parseISODate('2025-01-15'), null)).toBe(true);
+			expect(isDueOn(every2Scheduled, parseISODate('2025-01-15'), parseISODate('2025-01-14'))).toBe(false);
+			expect(isDueOn(every2Scheduled, parseISODate('2025-01-15'), parseISODate('2025-01-13'))).toBe(true);
+			expect(isDueOn(every2Scheduled, parseISODate('2025-01-15'), parseISODate('2025-01-10'))).toBe(true);
+		});
+
+		it('completion anchor uses the rolling window even when a scheduled date is supplied', () => {
+			const scheduled = parseISODate('2025-01-10');
+			// gap 1 < 2 → not due, even though 2025-01-14 is on the scheduled cadence
+			expect(isDueOn(every2Completion, parseISODate('2025-01-14'), parseISODate('2025-01-13'), scheduled)).toBe(false);
+			// gap 2 → due, even though 2025-01-15 is off the scheduled cadence
+			expect(isDueOn(every2Completion, parseISODate('2025-01-15'), parseISODate('2025-01-13'), scheduled)).toBe(true);
+		});
+
+		it('fixed-day kinds ignore scheduledDate', () => {
+			const monWedFri: ParsedRecurrence = { kind: 'weekly-bydays', byDays: new Set([1, 3, 5]) };
+			const scheduled = parseISODate('2025-01-14'); // a Tuesday
+			expect(isDueOn(monWedFri, parseISODate('2025-01-15'), null, scheduled)).toBe(true);  // Wed still due
+			expect(isDueOn(monWedFri, parseISODate('2025-01-14'), null, scheduled)).toBe(false); // Tue still not due
 		});
 	});
 

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -225,12 +225,14 @@ export class GraphRenderer {
 	static calculateStreak(
 		completionDates: Date[],
 		skippedDates: Date[] = [],
-		recurrencePattern: string = 'every day'
+		recurrencePattern: string = 'every day',
+		recurrenceAnchor: RecurrenceAnchor = 'scheduled',
+		scheduledDate: Date | null = null
 	): number {
 		if (completionDates.length === 0) return 0;
 
 		const today = getTodayUTC();
-		const recurrence = parseRecurrence(recurrencePattern);
+		const recurrence = parseRecurrence(recurrencePattern, recurrenceAnchor);
 
 		// Sort dates descending
 		const sorted = [...completionDates].sort((a, b) => b.getTime() - a.getTime());
@@ -250,7 +252,7 @@ export class GraphRenderer {
 					continue;
 				}
 				// Gap days where the habit wasn't due don't break the streak
-				if (!isDueOn(recurrence, currentDate, completionDate)) {
+				if (!isDueOn(recurrence, currentDate, completionDate, scheduledDate)) {
 					currentDate.setUTCDate(currentDate.getUTCDate() - 1);
 					continue;
 				}

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -83,11 +83,13 @@ export class GraphRenderer {
 			if (isToday) {
 				status = completed ? 'today-done' : skippedSet.has(dateStr) ? 'skipped' : 'today-missed';
 			} else if (isFuture) {
-				if (recurrence.kind !== 'interval') {
-					// Fixed calendar schedules: a future day is either due or not.
-					// No escalation ramp — "how overdue" has no meaning when due
-					// days don't drift with completion history.
-					status = isDueOn(recurrence, date, null) ? 'future-ok' : 'future-too-early';
+				if (recurrence.kind !== 'interval' ||
+					(recurrence.anchor === 'scheduled' && scheduledDate)) {
+					// Fixed calendar schedules (incl. scheduled-anchor cadence):
+					// a future day is either due or not. No escalation ramp —
+					// "how overdue" has no meaning when due days don't drift
+					// with completion history.
+					status = isDueOn(recurrence, date, null, scheduledDate) ? 'future-ok' : 'future-too-early';
 				} else if (daysSinceCompletion < intervalDays * 0.75) {
 					status = 'future-too-early';
 				} else if (daysSinceCompletion < intervalDays * 1.25) {

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -1,5 +1,5 @@
 import { formatISODate, getTodayUTC, isSameDay, addDays } from './utils/dateUtils';
-import { parseRecurrenceIntervalDays, parseRecurrence, isDueOn } from './utils/recurrenceUtils';
+import { parseRecurrenceIntervalDays, parseRecurrence, isDueOn, RecurrenceAnchor } from './utils/recurrenceUtils';
 
 export interface DayCell {
 	date: Date;
@@ -21,7 +21,9 @@ export class GraphRenderer {
 		daysBefore: number,
 		daysAfter: number,
 		recurrencePattern: string = 'every day',
-		skippedDates: Date[] = []
+		skippedDates: Date[] = [],
+		recurrenceAnchor: RecurrenceAnchor = 'scheduled',
+		scheduledDate: Date | null = null
 	): DayCell[] {
 		const cells: DayCell[] = [];
 		const today = getTodayUTC();
@@ -43,8 +45,9 @@ export class GraphRenderer {
 
 		// Parse recurrence to get ideal interval (in days) for the future window
 		const intervalDays = parseRecurrenceIntervalDays(recurrencePattern);
-		// Structured recurrence drives due-day decisions (fixed weekdays/monthdays)
-		const recurrence = parseRecurrence(recurrencePattern);
+		// Structured recurrence drives due-day decisions (fixed weekdays/monthdays,
+		// and scheduled-anchor interval cadence when a scheduled date exists)
+		const recurrence = parseRecurrence(recurrencePattern, recurrenceAnchor);
 
 		// Sort completions ascending for per-cell interval checks on past days
 		const sortedCompletions = [...completionDates].sort((a, b) => a.getTime() - b.getTime());
@@ -98,7 +101,7 @@ export class GraphRenderer {
 				// Past: only "missed" if the habit was actually due that day
 				status = completed ? 'done'
 					: skippedSet.has(dateStr) ? 'skipped'
-					: !isDueOn(recurrence, date, lastCompBeforeCell) ? 'rest'
+					: !isDueOn(recurrence, date, lastCompBeforeCell, scheduledDate) ? 'rest'
 					: 'missed';
 			}
 

--- a/src/habitGraphView.ts
+++ b/src/habitGraphView.ts
@@ -2,6 +2,7 @@ import { ItemView, WorkspaceLeaf } from 'obsidian';
 import type OrgHabitsGraphPlugin from './main';
 import { GraphRenderer } from './graphRenderer';
 import { openTaskNote } from './utils/noteOpener';
+import { parseISODateOrNull } from './utils/dateUtils';
 
 export const VIEW_TYPE_HABIT_GRAPH = 'habit-graph-view';
 
@@ -49,16 +50,19 @@ export class HabitGraphView extends ItemView {
 		for (const task of habitTasks) {
 			const completionDates = this.plugin.tasksApi.getCompletionHistory(task);
 			const skippedDates = this.plugin.tasksApi.getSkippedDates(task);
+			const scheduledDate = parseISODateOrNull(task.scheduled);
 
 			const cells = GraphRenderer.generateDayCells(
 				completionDates,
 				this.plugin.settings.daysBeforeToday,
 				this.plugin.settings.daysAfterToday,
 				task.recurrence,
-				skippedDates
+				skippedDates,
+				task.recurrenceAnchor,
+				scheduledDate
 			);
 
-			const streak = GraphRenderer.calculateStreak(completionDates, skippedDates, task.recurrence);
+			const streak = GraphRenderer.calculateStreak(completionDates, skippedDates, task.recurrence, task.recurrenceAnchor, scheduledDate);
 
 			const graphEl = GraphRenderer.renderGraph(
 				cells,

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { GraphRenderer } from './graphRenderer';
 import { TaskCacheManager } from './cache/TaskCacheManager';
 import { VaultEventHandler } from './events/VaultEventHandler';
 import { openTaskNote } from './utils/noteOpener';
+import { parseISODateOrNull } from './utils/dateUtils';
 
 export default class OrgHabitsGraphPlugin extends Plugin {
 	settings: HabitGraphSettings;
@@ -181,16 +182,19 @@ export default class OrgHabitsGraphPlugin extends Plugin {
 		for (const task of habitTasks) {
 			const completionDates = this.tasksApi.getCompletionHistory(task);
 			const skippedDates = this.tasksApi.getSkippedDates(task);
+			const scheduledDate = parseISODateOrNull(task.scheduled);
 
 			const cells = GraphRenderer.generateDayCells(
 				completionDates,
 				this.settings.daysBeforeToday,
 				this.settings.daysAfterToday,
 				task.recurrence,
-				skippedDates
+				skippedDates,
+				task.recurrenceAnchor,
+				scheduledDate
 			);
 
-			const streak = GraphRenderer.calculateStreak(completionDates, skippedDates, task.recurrence);
+			const streak = GraphRenderer.calculateStreak(completionDates, skippedDates, task.recurrence, task.recurrenceAnchor, scheduledDate);
 
 			const graphEl = GraphRenderer.renderGraph(
 				cells,

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -43,6 +43,29 @@ export function parseISODate(dateStr: string): Date {
 }
 
 /**
+ * Best-effort parse of a frontmatter date value to a UTC-midnight Date.
+ *
+ * Frontmatter is user-typed: values may be bare dates, datetime strings
+ * ("2025-01-15T09:00" from time-blocked TaskNotes), or garbage. This accepts
+ * anything with a leading YYYY-MM-DD (time portion discarded) and returns
+ * null instead of throwing on everything else, so a malformed `scheduled`
+ * value can never break rendering.
+ *
+ * @param dateStr - Raw frontmatter value, or undefined
+ * @returns Date at midnight UTC, or null if no valid leading date
+ */
+export function parseISODateOrNull(dateStr: string | undefined): Date | null {
+	if (!dateStr) return null;
+	const match = dateStr.match(/^(\d{4}-\d{2}-\d{2})/);
+	if (!match) return null;
+	try {
+		return parseISODate(match[1]);
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Format a Date object as an ISO date string (YYYY-MM-DD) in UTC.
  *
  * Replaces the fragile `.toISOString().split('T')[0]` pattern with

--- a/src/utils/recurrenceUtils.ts
+++ b/src/utils/recurrenceUtils.ts
@@ -71,10 +71,16 @@ export function parseRecurrenceIntervalDays(pattern: string): number {
 	return 1;
 }
 
+/** Frontmatter `recurrence_anchor` value; 'scheduled' is the TaskNote default. */
+export type RecurrenceAnchor = 'scheduled' | 'completion';
+
 /**
  * Structured recurrence representation.
  *
- * - 'interval': rolling window of N days since last completion
+ * - 'interval': every N days. With anchor 'completion' the window rolls from
+ *   the last completion; with anchor 'scheduled' due days are a fixed cadence
+ *   from the habit's scheduled date (isDueOn falls back to the rolling window
+ *   when no scheduled date is supplied)
  *   (FREQ=DAILY, FREQ=WEEKLY without BYDAY, legacy text patterns)
  * - 'weekly-bydays': due on fixed weekdays (FREQ=WEEKLY;BYDAY=MO,WE,FR);
  *   byDays uses JS weekday numbering, 0=Sunday..6=Saturday
@@ -82,7 +88,7 @@ export function parseRecurrenceIntervalDays(pattern: string): number {
  *   (FREQ=MONTHLY;BYMONTHDAY=1,15)
  */
 export type ParsedRecurrence =
-	| { kind: 'interval'; days: number }
+	| { kind: 'interval'; days: number; anchor: RecurrenceAnchor }
 	| { kind: 'weekly-bydays'; byDays: Set<number> }
 	| { kind: 'monthly-bymonthday'; byMonthDays: Set<number> };
 
@@ -103,8 +109,10 @@ const BYDAY_TO_WEEKDAY: Record<string, number> = {
  * Malformed fixed-day params (unrecognized BYDAY token, empty BYDAY,
  * BYMONTHDAY outside 1-31) log a warning and fall back to daily.
  * INTERVAL>1 combined with BYDAY is not supported: warns and treats as weekly.
+ * anchor 'completion' on a fixed-day schedule is a no-op: warns and stays
+ * calendar-fixed (rolling-window semantics don't apply to fixed due days).
  */
-export function parseRecurrence(pattern: string): ParsedRecurrence {
+export function parseRecurrence(pattern: string, anchor: RecurrenceAnchor = 'scheduled'): ParsedRecurrence {
 	const params = parseRRuleParams(pattern);
 
 	if (params) {
@@ -118,16 +126,19 @@ export function parseRecurrence(pattern: string): ParsedRecurrence {
 				const weekday = BYDAY_TO_WEEKDAY[token];
 				if (weekday === undefined) {
 					console.warn(`Unrecognized BYDAY token "${token}" in "${pattern}". Defaulting to daily (1 day).`);
-					return { kind: 'interval', days: 1 };
+					return { kind: 'interval', days: 1, anchor };
 				}
 				byDays.add(weekday);
 			}
 			if (byDays.size === 0) {
 				console.warn(`Empty BYDAY in "${pattern}". Defaulting to daily (1 day).`);
-				return { kind: 'interval', days: 1 };
+				return { kind: 'interval', days: 1, anchor };
 			}
 			if (interval > 1) {
 				console.warn(`INTERVAL=${interval} with BYDAY is not supported in "${pattern}". Treating as weekly.`);
+			}
+			if (anchor === 'completion') {
+				console.warn(`recurrence_anchor: completion has no effect on fixed-day schedule "${pattern}". Due days stay calendar-fixed.`);
 			}
 			return { kind: 'weekly-bydays', byDays };
 		}
@@ -139,40 +150,55 @@ export function parseRecurrence(pattern: string): ParsedRecurrence {
 				const day = parseInt(token, 10);
 				if (isNaN(day) || day < 1 || day > 31) {
 					console.warn(`Invalid BYMONTHDAY value "${token}" in "${pattern}". Defaulting to daily (1 day).`);
-					return { kind: 'interval', days: 1 };
+					return { kind: 'interval', days: 1, anchor };
 				}
 				byMonthDays.add(day);
 			}
 			if (byMonthDays.size === 0) {
 				console.warn(`Empty BYMONTHDAY in "${pattern}". Defaulting to daily (1 day).`);
-				return { kind: 'interval', days: 1 };
+				return { kind: 'interval', days: 1, anchor };
+			}
+			if (anchor === 'completion') {
+				console.warn(`recurrence_anchor: completion has no effect on fixed-day schedule "${pattern}". Due days stay calendar-fixed.`);
 			}
 			return { kind: 'monthly-bymonthday', byMonthDays };
 		}
 	}
 
-	return { kind: 'interval', days: parseRecurrenceIntervalDays(pattern) };
+	return { kind: 'interval', days: parseRecurrenceIntervalDays(pattern), anchor };
 }
 
 /**
  * Whether the habit is due on the given date.
  *
- * - 'interval': due when at least `days` have elapsed since the most recent
- *   completion strictly before `date` (rolling window). Due if there is no
- *   prior completion.
+ * - 'interval' with anchor 'scheduled' AND a non-null `scheduledDate`: due on
+ *   the fixed cadence scheduledDate, +days, +2*days, ... — completion history
+ *   is irrelevant, and days before the scheduled date are never due.
+ * - 'interval' otherwise (anchor 'completion', or anchor 'scheduled' without
+ *   a scheduled date): due when at least `days` have elapsed since the most
+ *   recent completion strictly before `date` (rolling window). Due if there
+ *   is no prior completion. The null-scheduledDate fallback is SILENT and
+ *   load-bearing: 'scheduled' is the frontmatter default, so most habits have
+ *   no scheduled date and must keep the legacy rolling-window behavior.
  * - 'weekly-bydays' / 'monthly-bymonthday': due on the fixed calendar days,
- *   independent of completion history.
+ *   independent of completion history and scheduledDate.
  *
- * `date` is expected to be a UTC-midnight Date (see dateUtils), so weekday
- * and day-of-month are read with getUTCDay()/getUTCDate().
+ * All Date params are expected to be UTC-midnight Dates (see dateUtils), so
+ * ms-diff day math is exact and weekday/day-of-month are read with
+ * getUTCDay()/getUTCDate().
  */
 export function isDueOn(
 	recurrence: ParsedRecurrence,
 	date: Date,
-	lastCompletionBefore: Date | null
+	lastCompletionBefore: Date | null,
+	scheduledDate: Date | null = null
 ): boolean {
 	switch (recurrence.kind) {
 		case 'interval': {
+			if (recurrence.anchor === 'scheduled' && scheduledDate) {
+				const daysSinceScheduled = Math.floor((date.getTime() - scheduledDate.getTime()) / MS_PER_DAY);
+				return daysSinceScheduled >= 0 && daysSinceScheduled % recurrence.days === 0;
+			}
 			if (!lastCompletionBefore) return true;
 			const gapDays = Math.floor((date.getTime() - lastCompletionBefore.getTime()) / MS_PER_DAY);
 			return gapDays >= recurrence.days;


### PR DESCRIPTION
## Summary
`TaskNote.recurrenceAnchor` was parsed from frontmatter but never consumed — interval habits always behaved as completion-anchored (rolling window) and fixed-day schedules as scheduled-anchored. This threads the anchor and the habit's `scheduled` date through the scheduling pipeline so both anchors work where they're meaningful.

## Issue Resolution
Closes #27

- Scheduled-anchor interval habits compute due days on a fixed cadence from the `scheduled` date (never due before it, completion history irrelevant)
- `recurrence_anchor: completion` on fixed-day schedules (BYDAY/BYMONTHDAY) is a documented no-op with a console warning
- Default behavior is unchanged when `recurrence_anchor`/`scheduled` are absent: scheduled-anchor without a scheduled date **silently falls back** to the legacy rolling window — this is the load-bearing rule that keeps every existing habit rendering identically (pinned by regression tests and a PROJECT_LORE invariant)

## Key Changes
- `recurrenceUtils`: `ParsedRecurrence` interval variant carries `anchor`; `parseRecurrence(pattern, anchor)`; `isDueOn(..., scheduledDate)`
- `graphRenderer`: past rest/missed cells, future cells, and `calculateStreak` all honor the anchor (new trailing params, behavior-preserving defaults). Scheduled-anchor habits with a real scheduled date get binary `future-ok`/`future-too-early` cells — the 0.75x/1.25x/1.5x escalation ramp is meaningless once due days are calendar-fixed
- `main.ts` / `habitGraphView.ts`: both call sites pass `task.recurrenceAnchor` + parsed scheduled date
- New `parseISODateOrNull` in `dateUtils`: tolerant frontmatter date parsing (accepts datetime strings like `2025-01-15T09:00`, returns null instead of throwing) so a malformed `scheduled` can never break rendering

## Implementation Notes
- Biweekly (`FREQ=WEEKLY;BYDAY=...;INTERVAL=2`) support is deliberately out of scope — this PR unblocks it (scheduledDate now reaches `isDueOn`); follow-up issue to be filed
- Today-cell behavior on non-due days is untouched (that's #28)

## Testing
162 tests pass (`jest --runInBand`), up from 132 — new coverage for scheduled-anchor cadence, fallback pinning against legacy rolling-window math, completion-anchor pass-through, binary future cells, and streak gap-days. Verified manually in the vault with a `FREQ=DAILY;INTERVAL=3` + `scheduled` test habit.