### PR TITLE
feat: Replace today glyphs with an in-place today tint (#33)

### DIFF
--- a/PROJECT_LORE.md
+++ b/PROJECT_LORE.md
@@ -12,6 +12,7 @@ make a wrong choice without this?
 - graphRenderer must guard `colorClass` before `setAttribute('class', ...)` on SVG `<g>` elements — *why: empty class attributes are harmless but the guard (`if (colorClass)`) prevents meaningless DOM writes; pattern replaced addClass() in the SVG rewrite*
 - SVG elements in graphRenderer must use `document.createElementNS('http://www.w3.org/2000/svg', ...)`, not `document.createElement()` — *why: createElement produces HTML elements that render invisible inside SVG context*
 - isDueOn's scheduled-anchor interval branch must SILENTLY fall back to rolling-window completion math when scheduledDate is null — *why: 'scheduled' is the frontmatter default and most habits set no scheduled date; this fallback is what keeps pre-#27 default behavior unchanged. Do not add a console.warn here (it's the common case) and do not "fix" it to throw*
+- The today `<line>` in renderGraph must be appended inside today's `<g>` AFTER the `rect` and BEFORE the marker `<text>` — *why: SVG paints in document order; reordering hides the `*`/`~` glyph under the accent line on today's cell*
 
 ## Gotchas
 
@@ -21,7 +22,7 @@ make a wrong choice without this?
 - TaskNotes plugin derives title from filename, not frontmatter — *why: parseTaskNoteFromFrontmatter must fall back to basename; requiring a `title` field causes "No habits found"*
 - Obsidian's `HTMLElement.addClass('')` throws — *why: unlike standard DOM classList.add, Obsidian's polyfill rejects empty strings; always guard with `if (value)` before calling*
 - Binary done/missed is wrong for interval habits in past days — *why: need sorted completion pointer to find most recent completion before each cell and check gap < intervalDays; without this, rest days show as red*
-- The `!`/`*!` today marker in renderGraph is driven by `cell.isToday`/`cell.completed`, NOT `cell.status` — *why: a non-due today reuses the plain 'rest' status (since #28) and still gets its marker; do not assume marker and status are coupled, and do not invent a 'today-rest' status to "keep the marker"*
+- Marker glyphs (markerForCell) are uniformly completed/status-driven (`*`/`~`/none) with NO today special-case, and `cell.isToday` is consumed only for placing the vertical today `<line>` (since #33) — *why: isToday looks dead if you only grep markers; do not reintroduce a `!` glyph or a 'today-rest' status, and a non-due today still reuses plain 'rest' (since #28)*
 - SVG graph uses percentage-based x/width on rects (no viewBox, no preserveAspectRatio) with fixed px font-size on text — *why: cells stretch to fill container while markers stay proportional; adding viewBox would distort text or prevent cell stretching*
 
 ## Glossary

--- a/PROJECT_LORE.md
+++ b/PROJECT_LORE.md
@@ -12,7 +12,7 @@ make a wrong choice without this?
 - graphRenderer must guard `colorClass` before `setAttribute('class', ...)` on SVG `<g>` elements — *why: empty class attributes are harmless but the guard (`if (colorClass)`) prevents meaningless DOM writes; pattern replaced addClass() in the SVG rewrite*
 - SVG elements in graphRenderer must use `document.createElementNS('http://www.w3.org/2000/svg', ...)`, not `document.createElement()` — *why: createElement produces HTML elements that render invisible inside SVG context*
 - isDueOn's scheduled-anchor interval branch must SILENTLY fall back to rolling-window completion math when scheduledDate is null — *why: 'scheduled' is the frontmatter default and most habits set no scheduled date; this fallback is what keeps pre-#27 default behavior unchanged. Do not add a console.warn here (it's the common case) and do not "fix" it to throw*
-- The today `<line>` in renderGraph must be appended inside today's `<g>` AFTER the `rect` and BEFORE the marker `<text>` — *why: SVG paints in document order; reordering hides the `*`/`~` glyph under the line on today's cell*
+- The today-overlay `<rect>` in renderGraph must be appended to the SVG root as a sibling AFTER today's `<g>`, never inside it — *why: the per-color rules (`.habit-graph-svg .blue rect` + `.theme-dark` variants) target every rect inside a color group and out-specify `.today-overlay`, silently making the tint invisible; the overlay is translucent so painting above the glyph is intended*
 
 ## Gotchas
 

--- a/PROJECT_LORE.md
+++ b/PROJECT_LORE.md
@@ -12,7 +12,7 @@ make a wrong choice without this?
 - graphRenderer must guard `colorClass` before `setAttribute('class', ...)` on SVG `<g>` elements — *why: empty class attributes are harmless but the guard (`if (colorClass)`) prevents meaningless DOM writes; pattern replaced addClass() in the SVG rewrite*
 - SVG elements in graphRenderer must use `document.createElementNS('http://www.w3.org/2000/svg', ...)`, not `document.createElement()` — *why: createElement produces HTML elements that render invisible inside SVG context*
 - isDueOn's scheduled-anchor interval branch must SILENTLY fall back to rolling-window completion math when scheduledDate is null — *why: 'scheduled' is the frontmatter default and most habits set no scheduled date; this fallback is what keeps pre-#27 default behavior unchanged. Do not add a console.warn here (it's the common case) and do not "fix" it to throw*
-- colorClassForCell's today override must exclude `'today-missed'` (yellow) and only that — *why: yellow is the call-to-action and only ever appears on today, so tinting/replacing it destroys the graph's main signal (learned across four rejected today-indicator designs in #33: center line, halo, tint overlay, frame); do not "restore" green for a completed today either — the `*` glyph carries done-ness on the purple cell*
+- colorClassForCell's `today` tint modifier must exclude `'today-missed'` (yellow) and only that, and 'today' is always appended to a base color class, never standalone — *why: yellow is the call-to-action and only ever appears on today, so tinting/replacing it destroys the graph's main signal (learned across five rejected today-indicator designs in #33: center line, halo, tint overlay, frame, flat purple); the tint is a CSS brightness filter on the base color, so a bare 'today' class renders an untinted transparent rect*
 
 ## Gotchas
 
@@ -22,7 +22,7 @@ make a wrong choice without this?
 - TaskNotes plugin derives title from filename, not frontmatter — *why: parseTaskNoteFromFrontmatter must fall back to basename; requiring a `title` field causes "No habits found"*
 - Obsidian's `HTMLElement.addClass('')` throws — *why: unlike standard DOM classList.add, Obsidian's polyfill rejects empty strings; always guard with `if (value)` before calling*
 - Binary done/missed is wrong for interval habits in past days — *why: need sorted completion pointer to find most recent completion before each cell and check gap < intervalDays; without this, rest days show as red*
-- Marker glyphs (markerForCell) are uniformly completed/status-driven (`*`/`~`/none) with NO today special-case; today is indicated by colorClassForCell's 'today' (purple) override instead (since #33) — *why: isToday looks dead if you only grep markers; do not reintroduce a `!` glyph or a 'today-rest' status, and a non-due today still reuses plain 'rest' (since #28)*
+- Marker glyphs (markerForCell) are uniformly completed/status-driven (`*`/`~`/none) with NO today special-case; today is indicated by colorClassForCell's 'today' brightness-tint modifier instead (since #33) — *why: isToday looks dead if you only grep markers; do not reintroduce a `!` glyph or a 'today-rest' status, and a non-due today still reuses plain 'rest' (since #28)*
 - SVG graph uses percentage-based x/width on rects (no viewBox, no preserveAspectRatio) with fixed px font-size on text — *why: cells stretch to fill container while markers stay proportional; adding viewBox would distort text or prevent cell stretching*
 
 ## Glossary

--- a/PROJECT_LORE.md
+++ b/PROJECT_LORE.md
@@ -12,7 +12,7 @@ make a wrong choice without this?
 - graphRenderer must guard `colorClass` before `setAttribute('class', ...)` on SVG `<g>` elements — *why: empty class attributes are harmless but the guard (`if (colorClass)`) prevents meaningless DOM writes; pattern replaced addClass() in the SVG rewrite*
 - SVG elements in graphRenderer must use `document.createElementNS('http://www.w3.org/2000/svg', ...)`, not `document.createElement()` — *why: createElement produces HTML elements that render invisible inside SVG context*
 - isDueOn's scheduled-anchor interval branch must SILENTLY fall back to rolling-window completion math when scheduledDate is null — *why: 'scheduled' is the frontmatter default and most habits set no scheduled date; this fallback is what keeps pre-#27 default behavior unchanged. Do not add a console.warn here (it's the common case) and do not "fix" it to throw*
-- The today-overlay `<rect>` in renderGraph must be appended to the SVG root as a sibling AFTER today's `<g>`, never inside it — *why: the per-color rules (`.habit-graph-svg .blue rect` + `.theme-dark` variants) target every rect inside a color group and out-specify `.today-overlay`, silently making the tint invisible; the overlay is translucent so painting above the glyph is intended*
+- colorClassForCell's today override must exclude `'today-missed'` (yellow) and only that — *why: yellow is the call-to-action and only ever appears on today, so tinting/replacing it destroys the graph's main signal (learned across four rejected today-indicator designs in #33: center line, halo, tint overlay, frame); do not "restore" green for a completed today either — the `*` glyph carries done-ness on the purple cell*
 
 ## Gotchas
 
@@ -22,7 +22,7 @@ make a wrong choice without this?
 - TaskNotes plugin derives title from filename, not frontmatter — *why: parseTaskNoteFromFrontmatter must fall back to basename; requiring a `title` field causes "No habits found"*
 - Obsidian's `HTMLElement.addClass('')` throws — *why: unlike standard DOM classList.add, Obsidian's polyfill rejects empty strings; always guard with `if (value)` before calling*
 - Binary done/missed is wrong for interval habits in past days — *why: need sorted completion pointer to find most recent completion before each cell and check gap < intervalDays; without this, rest days show as red*
-- Marker glyphs (markerForCell) are uniformly completed/status-driven (`*`/`~`/none) with NO today special-case, and `cell.isToday` is consumed only for placing the vertical today `<line>` (since #33) — *why: isToday looks dead if you only grep markers; do not reintroduce a `!` glyph or a 'today-rest' status, and a non-due today still reuses plain 'rest' (since #28)*
+- Marker glyphs (markerForCell) are uniformly completed/status-driven (`*`/`~`/none) with NO today special-case; today is indicated by colorClassForCell's 'today' (purple) override instead (since #33) — *why: isToday looks dead if you only grep markers; do not reintroduce a `!` glyph or a 'today-rest' status, and a non-due today still reuses plain 'rest' (since #28)*
 - SVG graph uses percentage-based x/width on rects (no viewBox, no preserveAspectRatio) with fixed px font-size on text — *why: cells stretch to fill container while markers stay proportional; adding viewBox would distort text or prevent cell stretching*
 
 ## Glossary

--- a/PROJECT_LORE.md
+++ b/PROJECT_LORE.md
@@ -12,7 +12,7 @@ make a wrong choice without this?
 - graphRenderer must guard `colorClass` before `setAttribute('class', ...)` on SVG `<g>` elements — *why: empty class attributes are harmless but the guard (`if (colorClass)`) prevents meaningless DOM writes; pattern replaced addClass() in the SVG rewrite*
 - SVG elements in graphRenderer must use `document.createElementNS('http://www.w3.org/2000/svg', ...)`, not `document.createElement()` — *why: createElement produces HTML elements that render invisible inside SVG context*
 - isDueOn's scheduled-anchor interval branch must SILENTLY fall back to rolling-window completion math when scheduledDate is null — *why: 'scheduled' is the frontmatter default and most habits set no scheduled date; this fallback is what keeps pre-#27 default behavior unchanged. Do not add a console.warn here (it's the common case) and do not "fix" it to throw*
-- The today `<line>` in renderGraph must be appended inside today's `<g>` AFTER the `rect` and BEFORE the marker `<text>` — *why: SVG paints in document order; reordering hides the `*`/`~` glyph under the accent line on today's cell*
+- The today `<line>` in renderGraph must be appended inside today's `<g>` AFTER the `rect` and BEFORE the marker `<text>` — *why: SVG paints in document order; reordering hides the `*`/`~` glyph under the line on today's cell*
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Morning workout                      Daily 🔥 12
 
 - **█ (Green)** - Task completed on this day
 - **░ (Red)** - Task missed on this day
-- **Purple** - Today's cell (unless the habit is due and not done — that stays yellow)
+- **Tinted cell** - Today (its normal color darkened/brightened in place; a due-but-not-done today stays full-strength yellow)
 - **Gray** - Future days (not yet due)
 - **🔥 12** - Current streak (12 days in a row)
 - **85% (18/21)** - Completion rate over the graph window

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Morning workout                      Daily 🔥 12
 
 - **█ (Green)** - Task completed on this day
 - **░ (Red)** - Task missed on this day
-- **Vertical accent line** - Today's indicator (spans all rows)
+- **Tinted column** - Today's indicator (today's cell is lightened/darkened across all rows)
 - **Gray** - Future days (not yet due)
 - **🔥 12** - Current streak (12 days in a row)
 - **85% (18/21)** - Completion rate over the graph window

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Morning workout                      Daily 🔥 12
 
 - **█ (Green)** - Task completed on this day
 - **░ (Red)** - Task missed on this day
-- **! (Border)** - Today's indicator
+- **Vertical accent line** - Today's indicator (spans all rows)
 - **Gray** - Future days (not yet due)
 - **🔥 12** - Current streak (12 days in a row)
 - **85% (18/21)** - Completion rate over the graph window

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Morning workout                      Daily 🔥 12
 
 - **█ (Green)** - Task completed on this day
 - **░ (Red)** - Task missed on this day
-- **Tinted column** - Today's indicator (today's cell is lightened/darkened across all rows)
+- **Purple** - Today's cell (unless the habit is due and not done — that stays yellow)
 - **Gray** - Future days (not yet due)
 - **🔥 12** - Current streak (12 days in a row)
 - **85% (18/21)** - Completion rate over the graph window

--- a/src/__tests__/graphRenderer.test.ts
+++ b/src/__tests__/graphRenderer.test.ts
@@ -501,3 +501,49 @@ describe('markerForCell — uniform glyphs, no today special-case (#33)', () => 
 		expect(GraphRenderer.markerForCell(makeCell({ isFuture: true, status: 'future-ok' }))).toBe('');
 	});
 });
+
+describe('colorClassForCell — dedicated today color, yellow always wins (#33)', () => {
+	function makeCell(overrides: Partial<DayCell>): DayCell {
+		return {
+			date: parseISODate('2025-01-15'),
+			isToday: false,
+			isPast: false,
+			isFuture: false,
+			completed: false,
+			daysFromLastCompletion: 0,
+			status: 'missed',
+			...overrides,
+		};
+	}
+
+	it('due-but-undone today stays yellow (call to action wins over today color)', () => {
+		const cell = makeCell({ isToday: true, status: 'today-missed' });
+		expect(GraphRenderer.colorClassForCell(cell)).toBe('yellow');
+	});
+
+	it('non-due today (rest) renders the today color, not blue', () => {
+		const cell = makeCell({ isToday: true, status: 'rest' });
+		expect(GraphRenderer.colorClassForCell(cell)).toBe('today');
+	});
+
+	it('completed today renders the today color (the * glyph carries done-ness)', () => {
+		const cell = makeCell({ isToday: true, completed: true, status: 'today-done' });
+		expect(GraphRenderer.colorClassForCell(cell)).toBe('today');
+	});
+
+	it('skipped today renders the today color (the ~ glyph carries skipped-ness)', () => {
+		const cell = makeCell({ isToday: true, status: 'skipped' });
+		expect(GraphRenderer.colorClassForCell(cell)).toBe('today');
+	});
+
+	it('non-today cells keep their status-driven colors', () => {
+		expect(GraphRenderer.colorClassForCell(makeCell({ isPast: true, status: 'done' }))).toBe('green');
+		expect(GraphRenderer.colorClassForCell(makeCell({ isPast: true, status: 'missed' }))).toBe('red');
+		expect(GraphRenderer.colorClassForCell(makeCell({ isPast: true, status: 'rest' }))).toBe('blue');
+		expect(GraphRenderer.colorClassForCell(makeCell({ isPast: true, status: 'skipped' }))).toBe('gray');
+		expect(GraphRenderer.colorClassForCell(makeCell({ isFuture: true, status: 'future-ok' }))).toBe('green-light');
+		expect(GraphRenderer.colorClassForCell(makeCell({ isFuture: true, status: 'future-too-early' }))).toBe('blue');
+		expect(GraphRenderer.colorClassForCell(makeCell({ isFuture: true, status: 'future-warning' }))).toBe('yellow');
+		expect(GraphRenderer.colorClassForCell(makeCell({ isFuture: true, status: 'future-overdue' }))).toBe('red');
+	});
+});

--- a/src/__tests__/graphRenderer.test.ts
+++ b/src/__tests__/graphRenderer.test.ts
@@ -502,7 +502,7 @@ describe('markerForCell — uniform glyphs, no today special-case (#33)', () => 
 	});
 });
 
-describe('colorClassForCell — dedicated today color, yellow always wins (#33)', () => {
+describe('colorClassForCell — today tint modifier, yellow always wins (#33)', () => {
 	function makeCell(overrides: Partial<DayCell>): DayCell {
 		return {
 			date: parseISODate('2025-01-15'),
@@ -521,19 +521,19 @@ describe('colorClassForCell — dedicated today color, yellow always wins (#33)'
 		expect(GraphRenderer.colorClassForCell(cell)).toBe('yellow');
 	});
 
-	it('non-due today (rest) renders the today color, not blue', () => {
+	it('non-due today (rest) keeps blue with the today tint modifier', () => {
 		const cell = makeCell({ isToday: true, status: 'rest' });
-		expect(GraphRenderer.colorClassForCell(cell)).toBe('today');
+		expect(GraphRenderer.colorClassForCell(cell)).toBe('blue today');
 	});
 
-	it('completed today renders the today color (the * glyph carries done-ness)', () => {
+	it('completed today keeps green with the today tint modifier', () => {
 		const cell = makeCell({ isToday: true, completed: true, status: 'today-done' });
-		expect(GraphRenderer.colorClassForCell(cell)).toBe('today');
+		expect(GraphRenderer.colorClassForCell(cell)).toBe('green today');
 	});
 
-	it('skipped today renders the today color (the ~ glyph carries skipped-ness)', () => {
+	it('skipped today keeps gray with the today tint modifier', () => {
 		const cell = makeCell({ isToday: true, status: 'skipped' });
-		expect(GraphRenderer.colorClassForCell(cell)).toBe('today');
+		expect(GraphRenderer.colorClassForCell(cell)).toBe('gray today');
 	});
 
 	it('non-today cells keep their status-driven colors', () => {

--- a/src/__tests__/graphRenderer.test.ts
+++ b/src/__tests__/graphRenderer.test.ts
@@ -451,3 +451,53 @@ describe('calculateStreak — monthly-bymonthday (#11)', () => {
 		expect(GraphRenderer.calculateStreak(completions, [], 'FREQ=MONTHLY;BYMONTHDAY=1,15')).toBe(1);
 	});
 });
+
+describe('markerForCell — uniform glyphs, no today special-case (#33)', () => {
+	function makeCell(overrides: Partial<DayCell>): DayCell {
+		return {
+			date: parseISODate('2025-01-15'),
+			isToday: false,
+			isPast: false,
+			isFuture: false,
+			completed: false,
+			daysFromLastCompletion: 0,
+			status: 'missed',
+			...overrides,
+		};
+	}
+
+	it('completed today gets a plain *, not *!', () => {
+		const cell = makeCell({ isToday: true, completed: true, status: 'today-done' });
+		expect(GraphRenderer.markerForCell(cell)).toBe('*');
+	});
+
+	it('uncompleted due today gets no glyph (the vertical line indicates today)', () => {
+		const cell = makeCell({ isToday: true, status: 'today-missed' });
+		expect(GraphRenderer.markerForCell(cell)).toBe('');
+	});
+
+	it('skipped today gets ~ (fixes the pre-existing !-instead-of-~ quirk)', () => {
+		const cell = makeCell({ isToday: true, status: 'skipped' });
+		expect(GraphRenderer.markerForCell(cell)).toBe('~');
+	});
+
+	it('non-due today (rest since #28) gets no glyph', () => {
+		const cell = makeCell({ isToday: true, status: 'rest' });
+		expect(GraphRenderer.markerForCell(cell)).toBe('');
+	});
+
+	it('completed past day gets *', () => {
+		const cell = makeCell({ isPast: true, completed: true, status: 'done' });
+		expect(GraphRenderer.markerForCell(cell)).toBe('*');
+	});
+
+	it('skipped past day gets ~', () => {
+		const cell = makeCell({ isPast: true, status: 'skipped' });
+		expect(GraphRenderer.markerForCell(cell)).toBe('~');
+	});
+
+	it('missed past days and future days get no glyph', () => {
+		expect(GraphRenderer.markerForCell(makeCell({ isPast: true, status: 'missed' }))).toBe('');
+		expect(GraphRenderer.markerForCell(makeCell({ isFuture: true, status: 'future-ok' }))).toBe('');
+	});
+});

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -129,10 +129,35 @@ export class GraphRenderer {
 
 	/**
 	 * Marker glyph for a cell — uniform across all days, including today.
-	 * Today is indicated by the vertical accent line, not a glyph.
+	 * Today is indicated by its dedicated cell color, not a glyph.
 	 */
 	static markerForCell(cell: DayCell): '' | '*' | '~' {
 		return cell.completed ? '*' : cell.status === 'skipped' ? '~' : '';
+	}
+
+	/**
+	 * Color class for a cell — status-driven, except that any today cell
+	 * NOT rendering yellow (today-missed) gets the dedicated 'today'
+	 * color so the current day stays findable. Yellow always wins: a
+	 * due-but-undone today is the graph's call to action. Completed and
+	 * skipped state still read from the * / ~ glyphs on the today cell.
+	 */
+	static colorClassForCell(cell: DayCell): string {
+		if (cell.isToday && cell.status !== 'today-missed') {
+			return 'today';
+		}
+		switch (cell.status) {
+			case 'done': return 'green';
+			case 'missed': return 'red';
+			case 'skipped': return 'gray';
+			case 'rest': return 'blue';
+			case 'future-too-early': return 'blue';
+			case 'future-ok': return 'green-light';
+			case 'future-warning': return 'yellow';
+			case 'future-overdue': return 'red';
+			case 'today-done': return 'green';
+			case 'today-missed': return 'yellow';
+		}
 	}
 
 	static renderGraph(
@@ -172,19 +197,7 @@ export class GraphRenderer {
 		for (let i = 0; i < cellCount; i++) {
 			const cell = cells[i];
 
-			let colorClass = '';
-			switch (cell.status) {
-				case 'done': colorClass = 'green'; break;
-				case 'missed': colorClass = 'red'; break;
-				case 'skipped': colorClass = 'gray'; break;
-				case 'rest': colorClass = 'blue'; break;
-				case 'future-too-early': colorClass = 'blue'; break;
-				case 'future-ok': colorClass = 'green-light'; break;
-				case 'future-warning': colorClass = 'yellow'; break;
-				case 'future-overdue': colorClass = 'red'; break;
-				case 'today-done': colorClass = 'green'; break;
-				case 'today-missed': colorClass = 'yellow'; break;
-			}
+			const colorClass = this.colorClassForCell(cell);
 
 			const g = document.createElementNS(svgNS, 'g');
 			if (colorClass) {
@@ -220,20 +233,6 @@ export class GraphRenderer {
 			g.appendChild(title);
 
 			svg.appendChild(g);
-
-			if (cell.isToday) {
-				// Sibling AFTER the <g>, never inside it: the per-color rules
-				// (.habit-graph-svg .blue rect, incl. .theme-dark variants)
-				// target every rect inside the color group and would override
-				// the tint fill. Translucent, so the */~ glyph reads through.
-				const overlay = document.createElementNS(svgNS, 'rect');
-				overlay.setAttribute('class', 'today-overlay');
-				overlay.setAttribute('x', `${cellWidthPct * i}%`);
-				overlay.setAttribute('y', '0');
-				overlay.setAttribute('width', `${cellWidthPct}%`);
-				overlay.setAttribute('height', '20');
-				svg.appendChild(overlay);
-			}
 		}
 
 		container.appendChild(svg);

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -82,8 +82,8 @@ export class GraphRenderer {
 
 			if (isToday) {
 				// Same precedence as the past branch: a non-due today is a rest
-				// day, not "missed". The `!` today marker survives — it keys off
-				// cell.isToday, not status.
+				// day, not "missed". Today stays findable via the vertical
+				// accent line renderGraph draws from cell.isToday.
 				status = completed ? 'today-done'
 					: skippedSet.has(dateStr) ? 'skipped'
 					: !isDueOn(recurrence, date, lastCompBeforeCell, scheduledDate) ? 'rest'
@@ -125,6 +125,14 @@ export class GraphRenderer {
 		}
 
 		return cells;
+	}
+
+	/**
+	 * Marker glyph for a cell — uniform across all days, including today.
+	 * Today is indicated by the vertical accent line, not a glyph.
+	 */
+	static markerForCell(cell: DayCell): '' | '*' | '~' {
+		return cell.completed ? '*' : cell.status === 'skipped' ? '~' : '';
 	}
 
 	static renderGraph(
@@ -190,14 +198,21 @@ export class GraphRenderer {
 			rect.setAttribute('height', '20');
 			g.appendChild(rect);
 
-			let marker = '';
 			if (cell.isToday) {
-				marker = cell.completed ? '*!' : '!';
-			} else if (cell.completed) {
-				marker = '*';
-			} else if (cell.status === 'skipped') {
-				marker = '~';
+				// Must sit between the rect and the marker <text>: the line
+				// paints over the cell background but under the glyph, so
+				// */~ stay legible on today's cell.
+				const line = document.createElementNS(svgNS, 'line');
+				line.setAttribute('class', 'today-line');
+				const centerX = `${cellWidthPct * i + cellWidthPct / 2}%`;
+				line.setAttribute('x1', centerX);
+				line.setAttribute('x2', centerX);
+				line.setAttribute('y1', '0');
+				line.setAttribute('y2', '20');
+				g.appendChild(line);
 			}
+
+			const marker = this.markerForCell(cell);
 
 			if (marker) {
 				const text = document.createElementNS(svgNS, 'text');

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -198,20 +198,6 @@ export class GraphRenderer {
 			rect.setAttribute('height', '20');
 			g.appendChild(rect);
 
-			if (cell.isToday) {
-				// Must sit between the rect and the marker <text>: the line
-				// paints over the cell background but under the glyph, so
-				// */~ stay legible on today's cell.
-				const line = document.createElementNS(svgNS, 'line');
-				line.setAttribute('class', 'today-line');
-				const centerX = `${cellWidthPct * i + cellWidthPct / 2}%`;
-				line.setAttribute('x1', centerX);
-				line.setAttribute('x2', centerX);
-				line.setAttribute('y1', '0');
-				line.setAttribute('y2', '20');
-				g.appendChild(line);
-			}
-
 			const marker = this.markerForCell(cell);
 
 			if (marker) {
@@ -234,6 +220,20 @@ export class GraphRenderer {
 			g.appendChild(title);
 
 			svg.appendChild(g);
+
+			if (cell.isToday) {
+				// Sibling AFTER the <g>, never inside it: the per-color rules
+				// (.habit-graph-svg .blue rect, incl. .theme-dark variants)
+				// target every rect inside the color group and would override
+				// the tint fill. Translucent, so the */~ glyph reads through.
+				const overlay = document.createElementNS(svgNS, 'rect');
+				overlay.setAttribute('class', 'today-overlay');
+				overlay.setAttribute('x', `${cellWidthPct * i}%`);
+				overlay.setAttribute('y', '0');
+				overlay.setAttribute('width', `${cellWidthPct}%`);
+				overlay.setAttribute('height', '20');
+				svg.appendChild(overlay);
+			}
 		}
 
 		container.appendChild(svg);

--- a/src/graphRenderer.ts
+++ b/src/graphRenderer.ts
@@ -129,35 +129,36 @@ export class GraphRenderer {
 
 	/**
 	 * Marker glyph for a cell — uniform across all days, including today.
-	 * Today is indicated by its dedicated cell color, not a glyph.
+	 * Today is indicated by its tinted cell color, not a glyph.
 	 */
 	static markerForCell(cell: DayCell): '' | '*' | '~' {
 		return cell.completed ? '*' : cell.status === 'skipped' ? '~' : '';
 	}
 
 	/**
-	 * Color class for a cell — status-driven, except that any today cell
-	 * NOT rendering yellow (today-missed) gets the dedicated 'today'
-	 * color so the current day stays findable. Yellow always wins: a
-	 * due-but-undone today is the graph's call to action. Completed and
-	 * skipped state still read from the * / ~ glyphs on the today cell.
+	 * Color class(es) for a cell — status-driven; today additionally gets
+	 * the 'today' modifier, which tints the normal status color in place
+	 * (a baked-in overlay, see styles.css) so the current day stays
+	 * findable. EXCEPT yellow (today-missed): a due-but-undone today is
+	 * the graph's call to action and keeps its full-strength color.
 	 */
 	static colorClassForCell(cell: DayCell): string {
-		if (cell.isToday && cell.status !== 'today-missed') {
-			return 'today';
-		}
+		let base: string;
 		switch (cell.status) {
-			case 'done': return 'green';
-			case 'missed': return 'red';
-			case 'skipped': return 'gray';
-			case 'rest': return 'blue';
-			case 'future-too-early': return 'blue';
-			case 'future-ok': return 'green-light';
-			case 'future-warning': return 'yellow';
-			case 'future-overdue': return 'red';
-			case 'today-done': return 'green';
-			case 'today-missed': return 'yellow';
+			case 'done': base = 'green'; break;
+			case 'missed': base = 'red'; break;
+			case 'skipped': base = 'gray'; break;
+			case 'rest': base = 'blue'; break;
+			case 'future-too-early': base = 'blue'; break;
+			case 'future-ok': base = 'green-light'; break;
+			case 'future-warning': base = 'yellow'; break;
+			case 'future-overdue': base = 'red'; break;
+			case 'today-done': base = 'green'; break;
+			case 'today-missed': base = 'yellow'; break;
 		}
+		return cell.isToday && cell.status !== 'today-missed'
+			? `${base} today`
+			: base;
 	}
 
 	static renderGraph(

--- a/styles.css
+++ b/styles.css
@@ -70,16 +70,12 @@
 .habit-graph-svg .gray rect { fill: #aaaaaa; }
 .habit-graph-svg .gray text { fill: white; }
 
-/* Today's column: a translucent strip over today's cell; stacked rows read
-   as one continuous band. --text-normal is near-black in light theme and
-   near-white in dark, so the strip darkens or lightens the cell without
-   changing its hue. The rect lives OUTSIDE the color <g> (see renderGraph)
-   so the .blue/.green/... rect rules can't override the fill. */
-.habit-graph-svg .today-overlay {
-	fill: var(--text-normal);
-	fill-opacity: 0.25;
-	stroke: none;
-}
+/* Today's cell: dedicated purple for any today status EXCEPT yellow
+   (today-missed) — a due-but-undone today is the graph's call to action
+   and always keeps its yellow. Purple is the one hue the status palette
+   doesn't use; * / ~ glyphs carry completed/skipped state on it. */
+.habit-graph-svg .today rect { fill: #9b59b6; }
+.habit-graph-svg .today text { fill: white; }
 
 .habit-graph-svg text {
 	font-family: var(--font-monospace);
@@ -133,3 +129,4 @@
 .theme-dark .habit-graph-svg .yellow rect { fill: #c8883e; }
 .theme-dark .habit-graph-svg .red rect { fill: #b43c39; }
 .theme-dark .habit-graph-svg .gray rect { fill: #888888; }
+.theme-dark .habit-graph-svg .today rect { fill: #7d4394; }

--- a/styles.css
+++ b/styles.css
@@ -70,14 +70,15 @@
 .habit-graph-svg .gray rect { fill: #aaaaaa; }
 .habit-graph-svg .gray text { fill: white; }
 
-/* Vertical line marking today's cell; stacked rows read as one continuous
-   line. --text-normal flips near-white/near-black with the theme; partial
-   opacity softens it from a hard rule into a spine that stays legible on
-   every cell color without overpowering them. */
-.habit-graph-svg .today-line {
-	stroke: var(--text-normal);
-	stroke-width: 2;
-	stroke-opacity: 0.5;
+/* Today's column: a translucent strip over today's cell; stacked rows read
+   as one continuous band. --text-normal is near-black in light theme and
+   near-white in dark, so the strip darkens or lightens the cell without
+   changing its hue. The rect lives OUTSIDE the color <g> (see renderGraph)
+   so the .blue/.green/... rect rules can't override the fill. */
+.habit-graph-svg .today-overlay {
+	fill: var(--text-normal);
+	fill-opacity: 0.25;
+	stroke: none;
 }
 
 .habit-graph-svg text {

--- a/styles.css
+++ b/styles.css
@@ -70,12 +70,12 @@
 .habit-graph-svg .gray rect { fill: #aaaaaa; }
 .habit-graph-svg .gray text { fill: white; }
 
-/* Today's cell: dedicated purple for any today status EXCEPT yellow
-   (today-missed) — a due-but-undone today is the graph's call to action
-   and always keeps its yellow. Purple is the one hue the status palette
-   doesn't use; * / ~ glyphs carry completed/skipped state on it. */
-.habit-graph-svg .today rect { fill: #9b59b6; }
-.habit-graph-svg .today text { fill: white; }
+/* Today's cell: the normal status color tinted in place — a baked-in
+   overlay. Darkened in light theme, brightened in dark theme (cells are
+   already dark there). The 'today' class is only ever applied alongside a
+   status color and NEVER to a yellow (today-missed) cell — a due-but-
+   undone today is the graph's call to action and stays full strength. */
+.habit-graph-svg .today rect { filter: brightness(0.7); }
 
 .habit-graph-svg text {
 	font-family: var(--font-monospace);
@@ -129,4 +129,4 @@
 .theme-dark .habit-graph-svg .yellow rect { fill: #c8883e; }
 .theme-dark .habit-graph-svg .red rect { fill: #b43c39; }
 .theme-dark .habit-graph-svg .gray rect { fill: #888888; }
-.theme-dark .habit-graph-svg .today rect { fill: #7d4394; }
+.theme-dark .habit-graph-svg .today rect { filter: brightness(1.35); }

--- a/styles.css
+++ b/styles.css
@@ -70,6 +70,13 @@
 .habit-graph-svg .gray rect { fill: #aaaaaa; }
 .habit-graph-svg .gray text { fill: white; }
 
+/* Vertical accent line marking today's cell; stacked rows read as one
+   continuous line. Theme variable adapts to light/dark and user accent. */
+.habit-graph-svg .today-line {
+	stroke: var(--interactive-accent);
+	stroke-width: 2;
+}
+
 .habit-graph-svg text {
 	font-family: var(--font-monospace);
 }

--- a/styles.css
+++ b/styles.css
@@ -70,11 +70,14 @@
 .habit-graph-svg .gray rect { fill: #aaaaaa; }
 .habit-graph-svg .gray text { fill: white; }
 
-/* Vertical accent line marking today's cell; stacked rows read as one
-   continuous line. Theme variable adapts to light/dark and user accent. */
+/* Vertical line marking today's cell; stacked rows read as one continuous
+   line. --text-normal flips near-white/near-black with the theme; partial
+   opacity softens it from a hard rule into a spine that stays legible on
+   every cell color without overpowering them. */
 .habit-graph-svg .today-line {
-	stroke: var(--interactive-accent);
+	stroke: var(--text-normal);
 	stroke-width: 2;
+	stroke-opacity: 0.5;
 }
 
 .habit-graph-svg text {


### PR DESCRIPTION
## Summary
The graph marked today with text glyphs (`!`, or a crowded `*!` when today was completed). Since the SVG rewrite (#24), today can be a graphical affordance. Final design after visual iteration: **today's cell keeps its normal status color, tinted in place** (darkened in light theme, brightened in dark) — **except yellow (`today-missed`), which stays full strength**, since a due-but-undone today is the graph's call to action and only ever appears on today.

## Issue Resolution
Closes #33

Marker selection is now a pure `markerForCell()` with uniform precedence for every day (`*` completed, `~` skipped, nothing otherwise). Deleting the `isToday` glyph branch also fixes the pre-existing quirk where a skipped today showed `!` instead of `~`. Cell coloring is likewise extracted into a pure `colorClassForCell()`: it returns the status color class, appending a `today` modifier (e.g. `blue today`) for every today status except `today-missed`. The modifier applies a CSS brightness filter — a baked-in overlay that preserves all color relationships.

## Key Changes
- `src/graphRenderer.ts` — glyph branch deleted; pure `markerForCell()` + `colorClassForCell()` (the color switch moved out of `renderGraph` into a testable function that also appends the `today` modifier)
- `styles.css` — `.today rect { filter: brightness(0.7) }` (light), `brightness(1.35)` under `.theme-dark`
- `PROJECT_LORE.md` — stale #28 marker gotcha rewritten; new invariant: the tint must exclude exactly `today-missed`, and `today` is always appended to a base color class, never standalone
- `README.md` — legend updated (`! (Border)` → tinted today cell, yellow exception noted)

## Implementation Notes
- `generateDayCells` / `cell.status` semantics untouched — pure presentation change; `cell.isToday` now feeds `colorClassForCell` instead of glyph selection.
- Design was iterated visually with the user (center line → halo → tint overlay rect → frame → flat purple → in-place tint); branch history keeps the intermediate attempts since the branch was already pushed with the PR open. The transferable lesson — yellow only ever appears on today, so any today-indicator that dims or replaces it degrades the primary signal — is pinned in PROJECT_LORE.

## Testing
- 12 new unit tests (182 total, run with `--runInBand`): 7 for `markerForCell` (no `!`/`*!` anywhere; `~` on skipped today) and 5 for `colorClassForCell` (yellow wins on due-today; `blue today`/`green today`/`gray today` for rest/done/skipped today; non-today colors unchanged) — first automated coverage of renderGraph's presentation logic (jest env is `node`; `renderGraph` itself remains manually verified)
- Manual vault verification across all design iterations, including a habit completed today (`*` on tinted green), due-today (yellow preserved), and non-due/skipped today cases